### PR TITLE
fix: Add --tuned flag to evaluate.py, fix notebook eval cells

### DIFF
--- a/colab_v2_pipeline.ipynb
+++ b/colab_v2_pipeline.ipynb
@@ -318,46 +318,28 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 6. Step 4 — Evaluate on Test Set\n",
-    "\n",
-    "Apply tuned thresholds to the held-out test set."
-   ]
+   "source": "## 6. Step 4 — Evaluate on Test Set\n\nApply tuned thresholds to the held-out test set. The `--tuned` flag auto-loads the best params from `tuning_results_v2.json`."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Standard evaluation — all conditions\n",
-    "!python evaluate.py --condition C1 --split test --version v2\n",
-    "!python evaluate.py --condition C2 --split test --version v2\n",
-    "!python evaluate.py --condition C3 --split test --version v2"
-   ]
+   "source": "# Standard evaluation — all conditions (--tuned loads best params from tuning)\n!python evaluate.py --condition C1 --split test --version v2\n!python evaluate.py --condition C2 --split test --version v2 --tuned\n!python evaluate.py --condition C3 --split test --version v2 --tuned"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Realistic evaluation\n",
-    "!python evaluate.py --condition C1 --split test --version v2 --realistic\n",
-    "!python evaluate.py --condition C2 --split test --version v2 --realistic\n",
-    "!python evaluate.py --condition C3 --split test --version v2 --realistic"
-   ]
+   "source": "# Realistic evaluation\n!python evaluate.py --condition C1 --split test --version v2 --realistic\n!python evaluate.py --condition C2 --split test --version v2 --realistic --tuned\n!python evaluate.py --condition C3 --split test --version v2 --realistic --tuned"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Ablation: evaluate with whole-response NLI scores (v2 without decomposition)\n",
-    "!python evaluate.py --condition C2 --split test --version v2 --nli-key nli_score_whole\n",
-    "!python evaluate.py --condition C3 --split test --version v2 --nli-key nli_score_whole"
-   ]
+   "source": "# Ablation: evaluate with whole-response NLI scores (v2 without decomposition)\n!python evaluate.py --condition C2 --split test --version v2 --nli-key nli_score_whole --tuned\n!python evaluate.py --condition C3 --split test --version v2 --nli-key nli_score_whole --tuned"
   },
   {
    "cell_type": "markdown",

--- a/evaluate.py
+++ b/evaluate.py
@@ -444,6 +444,8 @@ def main():
                         help="v1=baseline, v2=decomposition+windowed+calibration")
     parser.add_argument("--nli-key", default="nli_score",
                         help="NLI score column to use (default: nli_score)")
+    parser.add_argument("--tuned", action="store_true",
+                        help="Auto-load best params from tuning results")
     args = parser.parse_args()
 
     os.makedirs(RESULTS_DIR, exist_ok=True)
@@ -481,9 +483,31 @@ def main():
                                version=args.version)
 
     elif args.condition:
-        # Parse params (or use defaults)
+        # Parse params: --tuned loads from tuning results, --params takes JSON, else defaults
         if args.params:
             params = json.loads(args.params)
+        elif args.tuned and args.condition in ("C2", "C3"):
+            # Load best params from tuning results file
+            rsuffix = "_realistic" if args.realistic else ""
+            tuning_path = os.path.join(
+                RESULTS_DIR, f"tuning_results{rsuffix}{version_suffix}.json")
+            if not os.path.exists(tuning_path):
+                print(f"Error: tuning results not found at {tuning_path}")
+                print(f"Run: python tune.py --split dev{rsuffix}"
+                      f"{' --version ' + args.version if args.version != 'v1' else ''}")
+                return
+            with open(tuning_path) as f:
+                tuning = json.load(f)
+            if args.condition == "C2":
+                params = tuning["C2"]["best_params"]
+            else:
+                # Pick best C3 variant by F1
+                best_c3 = max(
+                    ["C3_tiered", "C3_sqrt", "C3_sigmoid"],
+                    key=lambda k: tuning[k]["best_f1"],
+                )
+                params = tuning[best_c3]["best_params"]
+            print(f"Loaded tuned params from {tuning_path}: {params}")
         else:
             if args.condition == "C1":
                 params = {}

--- a/run_v2.py
+++ b/run_v2.py
@@ -144,8 +144,9 @@ def main():
 
     # ---- Step 4: Evaluate on test ----
     for cond in ["C1", "C2", "C3"]:
+        tuned = " --tuned" if cond != "C1" else ""
         t = run(
-            f"python evaluate.py --condition {cond} --split test --version v2",
+            f"python evaluate.py --condition {cond} --split test --version v2{tuned}",
             f"Step 4/5: Evaluate {cond} on test set (v2)",
         )
         timings[f"eval_{cond}"] = t


### PR DESCRIPTION
evaluate.py --condition C2/C3 without --params used v1 default thresholds (T_static=0.75, T_strict=0.95) which are far too high for v2 NLI scores (~0.3-0.4 range), causing Recall=1.0 / Prec=0.50 (everything flagged as hallucination).

- Add --tuned flag: auto-loads best params from tuning_results JSON
- Update Colab notebook eval cells to use --tuned
- Update run_v2.py eval step to use --tuned