### PR TITLE
Address PR #26 review comments (docs scope only)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,29 @@
-# Website
+# AFLHR Lite Documentation
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+Built with [Docusaurus](https://docusaurus.io/).
 
 ## Installation
 
 ```bash
-yarn
+npm install
 ```
 
 ## Local Development
 
 ```bash
-yarn start
+npm start -- --port 4000
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+Or via the project root:
+
+```bash
+make start    # starts backend + frontend + docs
+```
 
 ## Build
 
 ```bash
-yarn build
+npm run build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-Using SSH:
-
-```bash
-USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```bash
-GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+Generates static files in `build/`.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ const config = {
 
   future: { v4: true },
 
-  url: 'http://localhost:4000',
+  url: process.env.DOCS_URL || 'http://localhost:4000',
   baseUrl: '/',
 
   onBrokenLinks: 'warn',
@@ -49,7 +49,7 @@ const config = {
             label: 'Documentation',
           },
           {
-            href: 'http://localhost:5173',
+            href: process.env.APP_URL || 'http://localhost:5173',
             label: '← Back to App',
             position: 'right',
           },

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -6,7 +6,7 @@ const navItems = [
   { path: '/', label: 'Verify' },
   { path: '/explore', label: 'Explore' },
   { path: '/about', label: 'How It Works' },
-  { href: 'http://localhost:4000', label: 'Docs', external: true },
+  { href: import.meta.env.VITE_DOCS_URL || 'http://localhost:4000', label: 'Docs', external: true },
 ]
 
 export default function Header({ health }) {


### PR DESCRIPTION
- Extract hardcoded localhost URLs to env vars:
  - Header.jsx: VITE_DOCS_URL with localhost:4000 fallback
  - docusaurus.config.js: DOCS_URL and APP_URL env vars
- Fix docs README: yarn → npm to match repo tooling