### PR TITLE
Finalize codebase for thesis submission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 frontend/
+docs/
 data/
 results/
 References/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.docx filter=lfs diff=lfs merge=lfs -text
+# Normalize line endings
+* text=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,15 @@ WORKDIR /app
 COPY requirements-deploy.txt .
 RUN pip install --no-cache-dir -r requirements-deploy.txt uvicorn
 
+# Pre-download NLTK data for sentence tokenization (claim decomposition)
+RUN python -c "import nltk; nltk.download('punkt_tab', quiet=True)"
+
 # Copy application code (only what the API needs)
 COPY engine.py config.py api.py ./
+
+# Pass at runtime: docker run -e GROQ_API_KEY=... image
+# Without it, the API runs in offline mode (mock LLM responses)
+ENV GROQ_API_KEY=""
 
 # HF Spaces expects port 7860
 ENV PORT=7860

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ start: stop
 # ── Stop ───────────────────────────────────────────────────────────────────────
 stop:
 	@pkill -f "uvicorn api:app" 2>/dev/null && echo "Stopped backend" || true
-	@pkill -f "vite" 2>/dev/null && echo "Stopped frontend" || true
-	@pkill -f "docusaurus start" 2>/dev/null && echo "Stopped docs" || true
+	@kill $$(cat $(PID_FRONTEND) 2>/dev/null) 2>/dev/null && echo "Stopped frontend" || true
+	@kill $$(cat $(PID_DOCS) 2>/dev/null) 2>/dev/null && echo "Stopped docs" || true
 	@rm -f $(PID_BACKEND) $(PID_FRONTEND) $(PID_DOCS)
 	@sleep 2
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone https://github.com/shaunyogeshwaran/Shaun_FYP.git
 cd Shaun_FYP
 make install        # installs pip + npm dependencies, creates .env
 # Edit .env and add your GROQ_API_KEY (free at https://console.groq.com)
-make start          # starts backend (:8000) + frontend (:5173)
+make start          # starts backend (:8000) + frontend (:5173) + docs (:4000)
 ```
 
 Open **http://localhost:5173** — that's it.
@@ -110,7 +110,7 @@ If you prefer manual setup over `make install`:
 ## Running the Demo
 
 ```bash
-make start     # starts backend (port 8000) + frontend (port 5173)
+make start     # starts backend (port 8000) + frontend (port 5173) + docs (port 4000)
 make stop      # stop both servers
 make restart   # bounce both servers
 make status    # check what's running
@@ -170,7 +170,7 @@ v2 adds four improvements over the baseline:
 ```bash
 python run_v2.py                   # full run (~4h on GPU, ~24h on CPU)
 python run_v2.py --limit 50        # smoke test (~minutes)
-python run_v2.py --skip-calibrate  # reuse existing calibration
+python run_v2.py --calibrate       # include calibration step (off by default)
 ```
 
 **Google Colab** (recommended for speed): Open `colab_v2_pipeline.ipynb` in Colab with a T4 GPU runtime for ~3-6 hour total runtime.

--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 """
 AFLHR Lite - FastAPI Backend
 REST API wrapping AFLHREngine for the React frontend.
-Supports both v1 (baseline) and v2 (decomposition + windowed NLI + calibration).
+Supports both v1 (baseline) and v2 (decomposition + windowed NLI + BGE embeddings).
 
 AI Disclosure: Development of this module was assisted by AI tools
 for code structuring, debugging, and refactoring. The API design and endpoint
@@ -33,7 +33,7 @@ app = FastAPI(title="AFLHR Lite API", version="2.0.0")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ VERIFIER_MODEL = "FacebookAI/roberta-large-mnli"
 GENERATOR_MODEL = "llama-3.1-8b-instant"  # Groq model ID
 
 # =============================================================================
-# Threshold Defaults (calibrate after first run)
+# Threshold Defaults (v1 baselines — v2 uses tuned values from grid search)
 # =============================================================================
 DEFAULT_PIVOT = 0.75
 DEFAULT_STRICT_THRESHOLD = 0.95

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -32,9 +32,9 @@ Main verification endpoint. Runs the full pipeline: retrieval → generation →
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `query` | string | *required* | The claim or question to verify |
-| `pivot` | float | 0.7 | Pivot threshold for tiered Cw-CONLI |
-| `strict_threshold` | float | 0.85 | Upper threshold (low retrieval confidence) |
-| `lenient_threshold` | float | 0.55 | Lower threshold (high retrieval confidence) |
+| `pivot` | float | 0.75 | Pivot threshold for tiered Cw-CONLI |
+| `strict_threshold` | float | 0.95 | Upper threshold (low retrieval confidence) |
+| `lenient_threshold` | float | 0.70 | Lower threshold (high retrieval confidence) |
 | `offline_mode` | bool | false | Skip LLM generation (use mock response) |
 | `v2_mode` | bool | false | Enable v2 features (windowed NLI, decomposition, BGE) |
 
@@ -55,17 +55,22 @@ curl -X POST http://localhost:8000/api/verify \
 {
   "query": "When was the University of Westminster founded?",
   "retrieval": {
-    "score": 0.877,
-    "top_passages": ["..."],
-    "topic": "University of Westminster"
+    "context": "The University of Westminster was founded in 1838...",
+    "retrieval_score": 0.877,
+    "raw_score": 0.754,
+    "documents": ["..."],
+    "indices": [0, 2]
   },
   "generation": "The University of Westminster was founded in 1838...",
   "nli_score": 0.883,
   "verdict": {
-    "label": "VERIFIED",
-    "threshold_mode": "LENIENT",
-    "threshold_used": 0.55,
-    "reasoning": "..."
+    "status": "VERIFIED",
+    "mode": "LENIENT",
+    "threshold": 0.70,
+    "nli_score": 0.883,
+    "retrieval_score": 0.877,
+    "reasoning": "High retrieval confidence -> trusting evidence quality",
+    "passed": true
   },
   "version": "v2",
   "nli_method": "decomposed",
@@ -84,9 +89,12 @@ Returns information about the loaded knowledge base.
 **Response:**
 ```json
 {
-  "topics": ["University of Westminster", "Machine Learning", "..."],
-  "total_passages": 6,
-  "embedding_model": "all-MiniLM-L6-v2"
+  "topics": [
+    {"name": "University of Westminster", "passages": 3},
+    {"name": "AI Hallucinations", "passages": 2},
+    {"name": "Climate of Sri Lanka (Distractor)", "passages": 1}
+  ],
+  "total_passages": 6
 }
 ```
 

--- a/engine.py
+++ b/engine.py
@@ -9,8 +9,8 @@ algorithm design, and research methodology are the author's own work.
 v2 improvements:
   - Sliding-window NLI (fixes 512-token truncation for long premises)
   - Sentence-level claim decomposition (addresses semantic illusion)
-  - NLI temperature scaling / calibration
   - Optional BGE embedding upgrade (ablation)
+  - NLI temperature scaling investigated (T=10 boundary — documented negative result)
 """
 
 import os

--- a/evaluate.py
+++ b/evaluate.py
@@ -445,7 +445,7 @@ def main():
     parser.add_argument("--realistic", action="store_true",
                         help="Experiment 2: shared-index retrieval (QA only)")
     parser.add_argument("--version", default="v1", choices=["v1", "v2"],
-                        help="v1=baseline, v2=decomposition+windowed+calibration")
+                        help="v1=baseline, v2=decomposition+windowed+bge")
     parser.add_argument("--nli-key", default="nli_score",
                         help="NLI score column to use (default: nli_score)")
     parser.add_argument("--tuned", action="store_true",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,8 +11,7 @@
         "framer-motion": "^12.38.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.13.1",
-        "recharts": "^3.8.0"
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -742,42 +741,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1135,18 +1098,6 @@
         "win32"
       ]
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1192,80 +1143,11 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1357,15 +1239,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1386,127 +1259,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1525,28 +1277,12 @@
         }
       }
     },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1596,12 +1332,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "node_modules/framer-motion": {
       "version": "12.38.0",
@@ -1653,25 +1383,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1837,36 +1548,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1914,57 +1595,6 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
-    },
-    "node_modules/recharts": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
-      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
-      }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -2046,12 +1676,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2087,37 +1711,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,7 @@
     "framer-motion": "^12.38.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.13.1",
-    "recharts": "^3.8.0"
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/frontend/src/components/BackgroundEffects.jsx
+++ b/frontend/src/components/BackgroundEffects.jsx
@@ -1,6 +1,7 @@
 // AI Disclosure: Development of this component was assisted by AI tools
 // for code structuring, debugging, and refactoring. The visual effects
 // design is the author's own work.
+import { useMemo } from 'react'
 import { useTheme } from '../ThemeContext'
 
 /**
@@ -9,6 +10,20 @@ import { useTheme } from '../ThemeContext'
  */
 export default function BackgroundEffects() {
   const { isDark } = useTheme()
+
+  // Memoize particle positions so they don't jump on re-renders
+  const particles = useMemo(() =>
+    Array.from({ length: 20 }, () => ({
+      left: `${Math.random() * 100}%`,
+      top: `${Math.random() * 100}%`,
+      animationDelay: `${Math.random() * 8}s`,
+      animationDuration: `${6 + Math.random() * 8}s`,
+      width: `${1.5 + Math.random() * 2}px`,
+      height: `${1.5 + Math.random() * 2}px`,
+      opacityDark: 0.2 + Math.random() * 0.35,
+      opacityLight: 0.15 + Math.random() * 0.2,
+    })),
+  [])
 
   return (
     <div style={{
@@ -21,18 +36,18 @@ export default function BackgroundEffects() {
       <div className={isDark ? 'orb orb-3' : 'orb orb-light-3'} />
 
       {/* Floating particles */}
-      {Array.from({ length: 20 }, (_, i) => (
+      {particles.map((p, i) => (
         <div
           key={i}
           className={isDark ? 'particle' : 'particle-light'}
           style={{
-            left: `${Math.random() * 100}%`,
-            top: `${Math.random() * 100}%`,
-            animationDelay: `${Math.random() * 8}s`,
-            animationDuration: `${6 + Math.random() * 8}s`,
-            width: `${1.5 + Math.random() * 2}px`,
-            height: `${1.5 + Math.random() * 2}px`,
-            opacity: isDark ? 0.2 + Math.random() * 0.35 : 0.15 + Math.random() * 0.2,
+            left: p.left,
+            top: p.top,
+            animationDelay: p.animationDelay,
+            animationDuration: p.animationDuration,
+            width: p.width,
+            height: p.height,
+            opacity: isDark ? p.opacityDark : p.opacityLight,
           }}
         />
       ))}

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -100,16 +100,3 @@ export const fonts = {
   body: "'DM Sans', sans-serif",
 }
 
-export const shadows = {
-  card: '0 2px 20px rgba(0, 0, 0, 0.4)',
-  glow: (color) => `0 0 30px ${color}`,
-  inset: 'inset 0 1px 0 rgba(255,255,255,0.03)',
-}
-
-export const radius = {
-  sm: 6,
-  md: 10,
-  lg: 16,
-  xl: 24,
-  full: '50%',
-}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    port: 5173,
     proxy: {
       '/api': 'http://localhost:8000',
     },

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -5,6 +5,7 @@ faiss-cpu>=1.9.0
 transformers>=4.35.0
 torch>=2.0.0
 langchain>=0.1.0
+langchain-core>=0.1.0
 langchain-community>=0.0.10
 langchain-groq>=0.1.0
 python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ torch>=2.0.0
 
 # LangChain
 langchain>=0.1.0
+langchain-core>=0.1.0
 langchain-community>=0.0.10
 langchain-groq>=0.1.0
 

--- a/run_v2.py
+++ b/run_v2.py
@@ -16,7 +16,7 @@ Runs the full v2 workflow end-to-end:
 Usage:
   python run_v2.py                    # full pipeline
   python run_v2.py --limit 50         # smoke test with 50 samples
-  python run_v2.py --skip-calibrate   # skip calibration (use existing)
+  python run_v2.py --calibrate         # include calibration step (off by default — T=10 boundary)
   python run_v2.py --skip-precompute  # skip precompute (use existing CSVs)
   python run_v2.py --realistic        # also run realistic retrieval experiment
 """
@@ -82,8 +82,10 @@ def main():
     parser = argparse.ArgumentParser(description="AFLHR v2 Full Pipeline")
     parser.add_argument("--limit", type=int, default=None,
                         help="Limit samples (for smoke testing)")
+    parser.add_argument("--calibrate", action="store_true",
+                        help="Run calibration step (off by default — T=10 boundary issue)")
     parser.add_argument("--skip-calibrate", action="store_true",
-                        help="Skip calibration step")
+                        help="(Deprecated) Calibration is now off by default")
     parser.add_argument("--skip-precompute", action="store_true",
                         help="Skip precomputation step")
     parser.add_argument("--skip-tune", action="store_true",
@@ -96,8 +98,8 @@ def main():
     total_start = time.time()
     timings = {}
 
-    # ---- Step 1: Calibrate ----
-    if not args.skip_calibrate:
+    # ---- Step 1: Calibrate (opt-in — T=10 boundary means it doesn't help) ----
+    if args.calibrate:
         t = run(
             f"python calibrate.py --split dev{limit_flag}",
             "Step 1/5: Calibrate NLI temperature on dev set",


### PR DESCRIPTION
## Summary

Comprehensive codebase finalization before thesis submission. Fixes #29.

- **Fix Vite port** 3000→5173 (was conflicting with Docusaurus on direct `npm run dev`)
- **Fix CORS** `allow_credentials=True` → `False` (spec violation with wildcard origins)
- **Fix `make stop`** — use PID files instead of `pkill -f "vite"` (was killing all Vite system-wide)
- **Fix calibration references** — docstrings/help text now note it's a documented negative result (T=10 boundary)
- **Make calibration opt-in** in `run_v2.py` (was wasting hours of compute by default)
- **Fix API docs** — response schemas, default thresholds, `/api/knowledge-base` response now match actual code
- **Harden Dockerfile** — pre-download NLTK punkt_tab, document GROQ_API_KEY env var, add `docs/` to .dockerignore
- **Add `langchain-core`** to requirements (explicit vs transitive dependency)
- **Remove unused `recharts`** (~200KB gzipped), unused theme exports (`shadows`, `radius`)
- **Fix particle render bug** — memoize `Math.random()` positions in BackgroundEffects
- **Update README** — `make start` mentions docs (:4000), calibration CLI updated
- **Clean `.gitattributes`** — replace vestigial LFS rule with line-ending normalization

## Test plan

- [ ] `make install` completes without errors
- [ ] `make start` launches backend (:8000), frontend (:5173), docs (:4000)
- [ ] `make stop` only kills AFLHR processes (not other Vite instances)
- [ ] Frontend loads without console errors, particles don't jump on theme toggle
- [ ] `/api/verify` returns response matching updated docs schema
- [ ] `python run_v2.py --help` shows `--calibrate` as opt-in flag

