### PR TITLE
Add edge case test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BACKEND_PORT := 8000
 FRONTEND_PORT := 5173
 DOCS_PORT := 4000
 
-.PHONY: start stop restart status backend frontend install smoke help
+.PHONY: start stop restart status backend frontend install smoke test test-all help
 
 # ── Default ────────────────────────────────────────────────────────────────────
 help:
@@ -16,6 +16,8 @@ help:
 	@echo "  make restart    Stop then start"
 	@echo "  make status     Show what's running"
 	@echo "  make install    Install all dependencies"
+	@echo "  make test       Run fast unit tests (~4s)"
+	@echo "  make test-all   Run all tests including slow integration (~60s)"
 	@echo "  make smoke      Smoke test (precompute 20 samples)"
 	@echo ""
 
@@ -75,3 +77,10 @@ install:
 # ── Smoke test ─────────────────────────────────────────────────────────────────
 smoke:
 	$(PYTHON) evaluate.py --precompute --split dev --version v2 --limit 20
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+test:
+	$(PYTHON) -m pytest tests/ -v
+
+test-all:
+	$(PYTHON) -m pytest tests/ -v --run-slow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures for AFLHR Lite test suite."""
+
+import os
+import sys
+import pytest
+
+# Ensure project root is on sys.path so imports work
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Suppress tokenizer parallelism warnings in tests
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-slow", action="store_true", default=False,
+        help="Run slow tests that require model loading (~30s startup)",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: requires model loading")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-slow"):
+        return
+    skip_slow = pytest.mark.skip(reason="needs --run-slow option")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+@pytest.fixture(scope="session")
+def engine_v1():
+    """Load a v1 engine (session-scoped so models load only once)."""
+    from engine import AFLHREngine
+    return AFLHREngine(
+        use_windowed_nli=False,
+        use_decomposition=False,
+        use_calibration=False,
+        use_bge_embeddings=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def engine_v2():
+    """Load a v2 engine (session-scoped so models load only once)."""
+    from engine import AFLHREngine
+    return AFLHREngine(
+        use_windowed_nli=True,
+        use_decomposition=True,
+        use_calibration=False,
+        use_bge_embeddings=True,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,213 @@
+"""Tests for FastAPI endpoints."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_engine():
+    """Create a mock AFLHREngine to avoid loading real models."""
+    engine = MagicMock()
+    engine.run_pipeline.return_value = {
+        "query": "test query",
+        "retrieval": {
+            "context": "test context",
+            "retrieval_score": 0.85,
+            "raw_score": 0.70,
+            "documents": ["doc1", "doc2"],
+            "indices": [0, 1],
+        },
+        "generation": "test response",
+        "nli_score": 0.90,
+        "verdict": {
+            "status": "VERIFIED",
+            "mode": "LENIENT",
+            "threshold": 0.70,
+            "nli_score": 0.90,
+            "retrieval_score": 0.85,
+            "reasoning": "High retrieval confidence",
+            "passed": True,
+        },
+    }
+    engine.verify_decomposed.return_value = {
+        "score": 0.88,
+        "mean_score": 0.90,
+        "per_claim": [
+            {"claim": "claim 1", "score": 0.92},
+            {"claim": "claim 2", "score": 0.88},
+        ],
+        "n_claims": 2,
+        "n_windows": 2,
+    }
+    engine.calculate_verdict.return_value = {
+        "status": "VERIFIED",
+        "mode": "LENIENT",
+        "threshold": 0.70,
+        "nli_score": 0.88,
+        "retrieval_score": 0.85,
+        "reasoning": "High retrieval confidence",
+        "passed": True,
+    }
+    return engine
+
+
+@pytest.fixture
+def client(mock_engine):
+    """Create a TestClient with mocked engines."""
+    import api
+    api.engine_v1 = mock_engine
+    api.engine_v2 = mock_engine
+    return TestClient(api.app)
+
+
+# ======================================================================
+# Health endpoint
+# ======================================================================
+
+class TestHealth:
+    def test_health_returns_ok(self, client):
+        r = client.get("/api/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        assert "engine_v1_loaded" in data
+        assert "engine_v2_loaded" in data
+        assert "has_api_key" in data
+
+
+# ======================================================================
+# Knowledge base endpoint
+# ======================================================================
+
+class TestKnowledgeBase:
+    def test_returns_topics(self, client):
+        r = client.get("/api/knowledge-base")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_passages"] == 6
+        assert len(data["topics"]) == 3
+
+    def test_topic_structure(self, client):
+        r = client.get("/api/knowledge-base")
+        topics = r.json()["topics"]
+        for topic in topics:
+            assert "name" in topic
+            assert "passages" in topic
+            assert isinstance(topic["passages"], int)
+
+
+# ======================================================================
+# Root endpoint
+# ======================================================================
+
+class TestRoot:
+    def test_root_returns_html(self, client):
+        r = client.get("/")
+        assert r.status_code == 200
+        assert "AFLHR Lite API" in r.text
+
+
+# ======================================================================
+# Verify endpoint
+# ======================================================================
+
+class TestVerify:
+    def test_basic_v1_verify(self, client):
+        r = client.post("/api/verify", json={
+            "query": "When was Westminster founded?",
+        })
+        assert r.status_code == 200
+        data = r.json()
+        assert data["version"] == "v1"
+        assert data["query"] == "test query"
+        assert "verdict" in data
+        assert "retrieval" in data
+        assert "nli_score" in data
+
+    def test_v2_verify(self, client):
+        r = client.post("/api/verify", json={
+            "query": "When was Westminster founded?",
+            "v2_mode": True,
+        })
+        assert r.status_code == 200
+        data = r.json()
+        assert data["version"] == "v2"
+        assert data["nli_method"] == "decomposed"
+        assert data["n_claims"] == 2
+        assert len(data["per_claim"]) == 2
+
+    def test_offline_mode(self, client, mock_engine):
+        r = client.post("/api/verify", json={
+            "query": "test",
+            "offline_mode": True,
+        })
+        assert r.status_code == 200
+        # Verify offline_mode was passed to the engine
+        call_kwargs = mock_engine.run_pipeline.call_args
+        assert call_kwargs.kwargs.get("offline_mode") is True or \
+               call_kwargs[1].get("offline_mode") is True
+
+    def test_custom_thresholds(self, client, mock_engine):
+        r = client.post("/api/verify", json={
+            "query": "test",
+            "pivot": 0.6,
+            "strict_threshold": 0.85,
+            "lenient_threshold": 0.55,
+        })
+        assert r.status_code == 200
+        call_kwargs = mock_engine.run_pipeline.call_args
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        # Thresholds should be passed through
+        assert kwargs.get("pivot") == 0.6 or call_kwargs[1].get("pivot") == 0.6
+
+    def test_missing_query_returns_422(self, client):
+        """Missing required 'query' field → 422 Unprocessable Entity."""
+        r = client.post("/api/verify", json={})
+        assert r.status_code == 422
+
+    def test_empty_query(self, client):
+        """Empty string query should still be accepted (validation is app-level)."""
+        r = client.post("/api/verify", json={"query": ""})
+        assert r.status_code == 200
+
+    def test_invalid_json(self, client):
+        """Malformed JSON → 422."""
+        r = client.post("/api/verify", content="not json",
+                        headers={"Content-Type": "application/json"})
+        assert r.status_code == 422
+
+    def test_extra_fields_ignored(self, client):
+        """Extra fields in request body should be silently ignored."""
+        r = client.post("/api/verify", json={
+            "query": "test",
+            "unknown_field": "should be ignored",
+        })
+        assert r.status_code == 200
+
+    def test_per_claim_scores_are_rounded(self, client):
+        """v2 per-claim scores should be rounded to 4 decimal places."""
+        r = client.post("/api/verify", json={
+            "query": "test",
+            "v2_mode": True,
+        })
+        data = r.json()
+        for claim in data["per_claim"]:
+            score_str = str(claim["score"])
+            # At most 4 decimal places
+            if "." in score_str:
+                assert len(score_str.split(".")[1]) <= 4
+
+
+# ======================================================================
+# CORS
+# ======================================================================
+
+class TestCORS:
+    def test_cors_headers_present(self, client):
+        """Preflight OPTIONS should return CORS headers."""
+        r = client.options("/api/health", headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+        })
+        assert "access-control-allow-origin" in r.headers

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,383 @@
+"""Tests for AFLHREngine — verdict logic, edge cases, and integration."""
+
+import math
+import pytest
+
+from engine import AFLHREngine
+from config import KNOWLEDGE_BASE
+
+
+# ======================================================================
+# Verdict calculation (pure logic — no models needed)
+# ======================================================================
+
+class TestCalculateVerdict:
+    """Test the tiered Cw-CONLI verdict logic."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Create a minimal engine mock with just the verdict method."""
+        # calculate_verdict is a pure method — we can call it on any instance
+        # but we need an instance. Use __new__ to skip __init__ (no model loading).
+        self.engine = object.__new__(AFLHREngine)
+
+    def test_strict_mode_verified(self):
+        """High NLI + low retrieval → STRICT mode, still VERIFIED."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.5, nli_score=0.96,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "VERIFIED"
+        assert v["mode"] == "STRICT"
+        assert v["passed"] is True
+        assert v["threshold"] == 0.95
+
+    def test_strict_mode_hallucination(self):
+        """Low NLI + low retrieval → STRICT mode, HALLUCINATION."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.5, nli_score=0.80,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "HALLUCINATION"
+        assert v["mode"] == "STRICT"
+        assert v["passed"] is False
+
+    def test_lenient_mode_verified(self):
+        """Moderate NLI + high retrieval → LENIENT mode, VERIFIED."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.85, nli_score=0.75,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "VERIFIED"
+        assert v["mode"] == "LENIENT"
+        assert v["passed"] is True
+        assert v["threshold"] == 0.70
+
+    def test_lenient_mode_hallucination(self):
+        """Low NLI + high retrieval → LENIENT mode, still HALLUCINATION."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.85, nli_score=0.50,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "HALLUCINATION"
+        assert v["mode"] == "LENIENT"
+        assert v["passed"] is False
+
+    def test_pivot_boundary_goes_lenient(self):
+        """Retrieval exactly at pivot → LENIENT (>= comparison)."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.75, nli_score=0.72,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["mode"] == "LENIENT"
+        assert v["passed"] is True
+
+    def test_nli_exactly_at_threshold(self):
+        """NLI exactly equal to threshold → VERIFIED (>= comparison)."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.5, nli_score=0.95,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["passed"] is True
+
+    def test_zero_scores(self):
+        """Both scores at 0 → STRICT mode, HALLUCINATION."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.0, nli_score=0.0,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "HALLUCINATION"
+        assert v["mode"] == "STRICT"
+
+    def test_perfect_scores(self):
+        """Both scores at 1.0 → LENIENT mode, VERIFIED."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=1.0, nli_score=1.0,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        assert v["status"] == "VERIFIED"
+        assert v["mode"] == "LENIENT"
+
+    def test_response_contains_all_fields(self):
+        """Verdict dict has all expected keys."""
+        v = self.engine.calculate_verdict(
+            retrieval_score=0.5, nli_score=0.8,
+            pivot=0.75, strict_threshold=0.95, lenient_threshold=0.70,
+        )
+        expected_keys = {"status", "mode", "threshold", "nli_score",
+                         "retrieval_score", "reasoning", "passed"}
+        assert set(v.keys()) == expected_keys
+
+
+# ======================================================================
+# Continuous verdict (sqrt / sigmoid)
+# ======================================================================
+
+class TestCalculateVerdictContinuous:
+    """Test continuous Cw-CONLI threshold variants."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.engine = object.__new__(AFLHREngine)
+
+    def test_sqrt_threshold_decreases_with_retrieval(self):
+        """Higher retrieval → lower threshold (more lenient) for sqrt."""
+        v_low = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.1, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sqrt",
+        )
+        v_high = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.9, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sqrt",
+        )
+        assert v_low["threshold"] > v_high["threshold"]
+
+    def test_sigmoid_threshold_decreases_with_retrieval(self):
+        """Higher retrieval → lower threshold for sigmoid."""
+        v_low = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.1, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sigmoid",
+        )
+        v_high = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.9, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sigmoid",
+        )
+        assert v_low["threshold"] > v_high["threshold"]
+
+    def test_sqrt_at_zero_retrieval(self):
+        """sqrt(0) = 0, so threshold = T_strict."""
+        v = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.0, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sqrt",
+        )
+        assert abs(v["threshold"] - 0.9) < 1e-6
+
+    def test_sqrt_at_one_retrieval(self):
+        """sqrt(1) = 1, so threshold = T_lenient."""
+        v = self.engine.calculate_verdict_continuous(
+            retrieval_score=1.0, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sqrt",
+        )
+        assert abs(v["threshold"] - 0.3) < 1e-6
+
+    def test_unknown_method_raises(self):
+        """Unknown continuous method should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown continuous method"):
+            self.engine.calculate_verdict_continuous(
+                retrieval_score=0.5, nli_score=0.5,
+                T_strict=0.9, T_lenient=0.3, method="linear",
+            )
+
+    def test_continuous_verdict_fields(self):
+        """Continuous verdict has expected fields."""
+        v = self.engine.calculate_verdict_continuous(
+            retrieval_score=0.5, nli_score=0.5,
+            T_strict=0.9, T_lenient=0.3, method="sqrt",
+        )
+        assert "CONTINUOUS_SQRT" == v["mode"]
+        assert "threshold" in v
+        assert "passed" in v
+
+
+# ======================================================================
+# Calibration guard
+# ======================================================================
+
+class TestCalibrationGuard:
+    """Test that calibration boundary detection works."""
+
+    def test_calibration_T_at_boundary_falls_back(self, tmp_path):
+        """T >= 9.0 should fall back to T=1.0."""
+        import json
+        import engine as engine_mod
+        cal_path = tmp_path / "cal.json"
+        cal_path.write_text(json.dumps({"temperature": 10.0}))
+
+        eng = object.__new__(AFLHREngine)
+        eng.use_calibration = True
+        eng.calibration_T = 1.0
+
+        original = engine_mod.CALIBRATION_TEMP_PATH
+        engine_mod.CALIBRATION_TEMP_PATH = str(cal_path)
+        try:
+            eng._load_calibration()
+            assert eng.calibration_T == 1.0  # fell back
+        finally:
+            engine_mod.CALIBRATION_TEMP_PATH = original
+
+    def test_calibration_normal_T_loads(self, tmp_path):
+        """Normal T (e.g. 1.5) should load successfully."""
+        import json
+        import engine as engine_mod
+        cal_path = tmp_path / "cal.json"
+        cal_path.write_text(json.dumps({"temperature": 1.5}))
+
+        eng = object.__new__(AFLHREngine)
+        eng.use_calibration = True
+        eng.calibration_T = 1.0
+
+        original = engine_mod.CALIBRATION_TEMP_PATH
+        engine_mod.CALIBRATION_TEMP_PATH = str(cal_path)
+        try:
+            eng._load_calibration()
+            assert eng.calibration_T == 1.5
+        finally:
+            engine_mod.CALIBRATION_TEMP_PATH = original
+
+    def test_calibration_missing_file(self, tmp_path):
+        """Missing calibration file should stay at T=1.0."""
+        import engine as engine_mod
+
+        eng = object.__new__(AFLHREngine)
+        eng.use_calibration = True
+        eng.calibration_T = 1.0
+
+        original = engine_mod.CALIBRATION_TEMP_PATH
+        engine_mod.CALIBRATION_TEMP_PATH = str(tmp_path / "nonexistent.json")
+        try:
+            eng._load_calibration()
+            assert eng.calibration_T == 1.0
+        finally:
+            engine_mod.CALIBRATION_TEMP_PATH = original
+
+
+# ======================================================================
+# Integration tests (require model loading — slow)
+# ======================================================================
+
+@pytest.mark.slow
+class TestEngineIntegration:
+    """Integration tests that load real models."""
+
+    def test_knowledge_base_indexed(self, engine_v1):
+        """FAISS index should have all knowledge base passages."""
+        assert engine_v1.faiss_index is not None
+        assert engine_v1.faiss_index.ntotal == len(KNOWLEDGE_BASE)
+
+    def test_retrieve_returns_valid_structure(self, engine_v1):
+        """Retrieve returns expected dict structure."""
+        result = engine_v1.retrieve("University of Westminster", k=2)
+        assert "context" in result
+        assert "retrieval_score" in result
+        assert "documents" in result
+        assert 0 <= result["retrieval_score"] <= 1
+        assert len(result["documents"]) == 2
+
+    def test_retrieve_relevant_topic(self, engine_v1):
+        """Westminster query should retrieve Westminster passages."""
+        result = engine_v1.retrieve("When was University of Westminster founded?")
+        assert "Westminster" in result["context"]
+
+    def test_retrieve_distractor_lower_score(self, engine_v1):
+        """Sri Lanka query should have lower score for Westminster index."""
+        r_relevant = engine_v1.retrieve("University of Westminster history")
+        r_distractor = engine_v1.retrieve("tropical monsoon weather patterns")
+        # Distractor should score lower (less relevant to most passages)
+        assert r_relevant["retrieval_score"] >= r_distractor["retrieval_score"]
+
+    def test_verify_entailment(self, engine_v1):
+        """Clear entailment should score high."""
+        score = engine_v1.verify(
+            premise="The sky is blue.",
+            hypothesis="The sky is blue.",
+        )
+        assert score > 0.8
+
+    def test_verify_contradiction(self, engine_v1):
+        """Clear contradiction should score low."""
+        score = engine_v1.verify(
+            premise="The sky is blue.",
+            hypothesis="The sky is red and green.",
+        )
+        assert score < 0.3
+
+    def test_verify_empty_hypothesis(self, engine_v1):
+        """Empty hypothesis should not crash."""
+        score = engine_v1.verify(premise="The sky is blue.", hypothesis="")
+        assert isinstance(score, float)
+        assert 0 <= score <= 1
+
+    def test_verify_windowed_short_premise(self, engine_v2):
+        """Short premise should use single-pass (not windowed)."""
+        result = engine_v2.verify_windowed(
+            premise="The sky is blue.",
+            hypothesis="The sky is blue.",
+        )
+        assert result["method"] == "single_pass"
+        assert result["n_windows"] == 1
+        assert result["score"] > 0.5
+
+    def test_verify_windowed_long_premise(self, engine_v2):
+        """Long premise should trigger windowed NLI."""
+        long_premise = " ".join(["This is a test sentence about various topics."] * 200)
+        result = engine_v2.verify_windowed(
+            premise=long_premise,
+            hypothesis="This is about various topics.",
+        )
+        assert result["n_windows"] >= 1
+        assert 0 <= result["score"] <= 1
+
+    def test_decompose_claims_multiple(self, engine_v2):
+        """Multi-sentence text should decompose into multiple claims."""
+        text = "The sky is blue. Water is wet. Fire is hot."
+        claims = engine_v2.decompose_claims(text)
+        assert len(claims) == 3
+
+    def test_decompose_claims_single(self, engine_v2):
+        """Single sentence should return one claim."""
+        claims = engine_v2.decompose_claims("The sky is blue.")
+        assert len(claims) == 1
+
+    def test_decompose_claims_empty(self, engine_v2):
+        """Empty string should return empty list."""
+        claims = engine_v2.decompose_claims("")
+        assert len(claims) == 0
+
+    def test_decompose_claims_short_fragments_filtered(self, engine_v2):
+        """Fragments under 5 chars should be filtered out."""
+        claims = engine_v2.decompose_claims("Hi. The sky is blue. Ok.")
+        # "Hi." and "Ok." are under 5 chars — should be filtered
+        assert all(len(c) >= 5 for c in claims)
+
+    def test_verify_decomposed_structure(self, engine_v2):
+        """Decomposed verification returns expected structure."""
+        result = engine_v2.verify_decomposed(
+            premise="The University of Westminster was founded in 1838.",
+            hypothesis="Westminster was founded in 1838. It is in London.",
+        )
+        assert "score" in result
+        assert "mean_score" in result
+        assert "per_claim" in result
+        assert "n_claims" in result
+        assert result["n_claims"] == 2
+        assert len(result["per_claim"]) == 2
+        # Min aggregation: score should be <= mean
+        assert result["score"] <= result["mean_score"] + 1e-6
+
+    def test_offline_generation(self, engine_v1):
+        """Offline mode returns mock response."""
+        from config import OFFLINE_MOCK_RESPONSE
+        response = engine_v1.generate("context", "query", offline_mode=True)
+        assert response == OFFLINE_MOCK_RESPONSE
+
+    def test_precompute_scores_structure(self, engine_v1):
+        """precompute_scores returns all expected fields."""
+        scores = engine_v1.precompute_scores(
+            knowledge="The sky is blue.",
+            query="What color is the sky?",
+            response="The sky is blue.",
+        )
+        expected = {"retrieval_score", "nli_score", "nli_score_whole",
+                    "nli_mean_score", "n_claims", "n_windows",
+                    "nli_method", "latency_ms"}
+        assert expected == set(scores.keys())
+        assert scores["nli_method"] == "whole"  # v1 engine
+
+    def test_precompute_scores_v2_decomposed(self, engine_v2):
+        """v2 precompute uses decomposed method."""
+        scores = engine_v2.precompute_scores(
+            knowledge="The sky is blue.",
+            query="What color is the sky?",
+            response="The sky is blue.",
+        )
+        assert scores["nli_method"] == "decomposed"

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,300 @@
+"""Tests for evaluation harness — condition logic, metrics, and dataset loading."""
+
+import math
+import pytest
+import numpy as np
+
+from evaluate import apply_condition, compute_metrics, load_precomputed
+from dataset import load_halueval, split_dev_test
+from config import EXPERIMENT_SEED, DEV_SPLIT_RATIO
+
+
+# ======================================================================
+# apply_condition
+# ======================================================================
+
+class TestApplyCondition:
+    """Test condition application on pre-computed scores."""
+
+    def _make_scores(self, retrieval=0.5, nli=0.8, label=1):
+        return [{
+            "sample_id": 0, "task": "qa", "label": label,
+            "retrieval_score": retrieval, "nli_score": nli,
+            "latency_ms": 10.0,
+        }]
+
+    def test_c1_always_accepts(self):
+        """C1 (RAG-only) should always predict 0 (verified)."""
+        scores = self._make_scores(nli=0.01)
+        preds = apply_condition(scores, "C1", {})
+        assert preds == [0]
+
+    def test_c2_above_threshold(self):
+        """C2: NLI >= T_static → verified (0)."""
+        scores = self._make_scores(nli=0.80)
+        preds = apply_condition(scores, "C2", {"T_static": 0.75})
+        assert preds == [0]
+
+    def test_c2_below_threshold(self):
+        """C2: NLI < T_static → hallucination (1)."""
+        scores = self._make_scores(nli=0.70)
+        preds = apply_condition(scores, "C2", {"T_static": 0.75})
+        assert preds == [1]
+
+    def test_c2_at_threshold(self):
+        """C2: NLI exactly at T_static → verified (>= comparison)."""
+        scores = self._make_scores(nli=0.75)
+        preds = apply_condition(scores, "C2", {"T_static": 0.75})
+        assert preds == [0]
+
+    def test_c3_tiered_strict(self):
+        """C3 tiered: low retrieval → uses strict threshold."""
+        scores = self._make_scores(retrieval=0.5, nli=0.80)
+        preds = apply_condition(scores, "C3", {
+            "method": "tiered", "pivot": 0.75,
+            "T_strict": 0.90, "T_lenient": 0.60,
+        })
+        assert preds == [1]  # 0.80 < 0.90 → hallucination
+
+    def test_c3_tiered_lenient(self):
+        """C3 tiered: high retrieval → uses lenient threshold."""
+        scores = self._make_scores(retrieval=0.80, nli=0.70)
+        preds = apply_condition(scores, "C3", {
+            "method": "tiered", "pivot": 0.75,
+            "T_strict": 0.90, "T_lenient": 0.60,
+        })
+        assert preds == [0]  # 0.70 >= 0.60 → verified
+
+    def test_c3_sqrt(self):
+        """C3 sqrt: threshold computed via sqrt formula."""
+        scores = self._make_scores(retrieval=0.64, nli=0.5)
+        preds = apply_condition(scores, "C3", {
+            "method": "sqrt", "T_strict": 0.9, "T_lenient": 0.3,
+        })
+        # T = 0.9 - (0.9-0.3)*sqrt(0.64) = 0.9 - 0.6*0.8 = 0.42
+        # nli=0.5 >= 0.42 → verified
+        assert preds == [0]
+
+    def test_c3_sigmoid(self):
+        """C3 sigmoid: threshold computed via sigmoid formula."""
+        scores = self._make_scores(retrieval=0.5, nli=0.65)
+        preds = apply_condition(scores, "C3", {
+            "method": "sigmoid", "T_strict": 0.9, "T_lenient": 0.3,
+            "sigmoid_k": 10, "sigmoid_pivot": 0.5,
+        })
+        # At pivot, sigmoid term = 0.5, so T = 0.3 + 0.6/2 = 0.6
+        # nli=0.65 >= 0.6 → verified
+        assert preds == [0]
+
+    def test_unknown_condition_raises(self):
+        scores = self._make_scores()
+        with pytest.raises(ValueError, match="Unknown condition"):
+            apply_condition(scores, "C4", {})
+
+    def test_unknown_c3_method_raises(self):
+        scores = self._make_scores()
+        with pytest.raises(ValueError, match="Unknown C3 method"):
+            apply_condition(scores, "C3", {"method": "linear", "T_strict": 0.9, "T_lenient": 0.3})
+
+    def test_alternate_nli_key(self):
+        """Should use nli_score_whole when specified."""
+        scores = [{
+            "sample_id": 0, "task": "qa", "label": 1,
+            "retrieval_score": 0.5, "nli_score": 0.80,
+            "nli_score_whole": 0.50,  # lower than nli_score
+            "latency_ms": 10.0,
+        }]
+        # With default key, 0.80 >= 0.75 → verified
+        preds_default = apply_condition(scores, "C2", {"T_static": 0.75})
+        assert preds_default == [0]
+        # With whole key, 0.50 < 0.75 → hallucination
+        preds_whole = apply_condition(scores, "C2", {"T_static": 0.75},
+                                      nli_key="nli_score_whole")
+        assert preds_whole == [1]
+
+    def test_multiple_samples(self):
+        """Apply condition across multiple samples."""
+        scores = [
+            {"sample_id": 0, "task": "qa", "label": 1,
+             "retrieval_score": 0.5, "nli_score": 0.80, "latency_ms": 10},
+            {"sample_id": 1, "task": "qa", "label": 0,
+             "retrieval_score": 0.5, "nli_score": 0.60, "latency_ms": 10},
+            {"sample_id": 2, "task": "qa", "label": 1,
+             "retrieval_score": 0.5, "nli_score": 0.75, "latency_ms": 10},
+        ]
+        preds = apply_condition(scores, "C2", {"T_static": 0.75})
+        assert preds == [0, 1, 0]  # 0.80>=0.75, 0.60<0.75, 0.75>=0.75
+
+
+# ======================================================================
+# compute_metrics
+# ======================================================================
+
+class TestComputeMetrics:
+    def test_perfect_predictions(self):
+        labels = [1, 1, 0, 0]
+        preds = [1, 1, 0, 0]
+        m = compute_metrics(labels, preds)
+        assert m["f1"] == 1.0
+        assert m["precision"] == 1.0
+        assert m["recall"] == 1.0
+        assert m["accuracy"] == 1.0
+        assert m["over_flagging_rate"] == 0.0
+
+    def test_all_wrong(self):
+        labels = [1, 1, 0, 0]
+        preds = [0, 0, 1, 1]
+        m = compute_metrics(labels, preds)
+        assert m["f1"] == 0.0
+        assert m["tp"] == 0
+        assert m["fp"] == 2
+        assert m["fn"] == 2
+        assert m["tn"] == 0
+
+    def test_empty_input(self):
+        m = compute_metrics([], [])
+        assert m["f1"] == 0.0
+        assert m["tp"] == 0
+
+    def test_all_positive(self):
+        """All predicted positive."""
+        labels = [1, 0, 1, 0]
+        preds = [1, 1, 1, 1]
+        m = compute_metrics(labels, preds)
+        assert m["recall"] == 1.0
+        assert m["fp"] == 2
+        assert m["over_flagging_rate"] == 1.0  # FP / (FP+TN) = 2/2
+
+    def test_all_negative(self):
+        """All predicted negative (like C1)."""
+        labels = [1, 1, 0, 0]
+        preds = [0, 0, 0, 0]
+        m = compute_metrics(labels, preds)
+        assert m["recall"] == 0.0
+        assert m["f1"] == 0.0
+        assert m["tn"] == 2
+
+    def test_with_latencies(self):
+        labels = [1, 0]
+        preds = [1, 0]
+        m = compute_metrics(labels, preds, latencies=[100.0, 200.0])
+        assert m["mean_latency_ms"] == 150.0
+        assert m["median_latency_ms"] == 150.0
+
+    def test_confusion_matrix_counts(self):
+        """Verify TP/FP/TN/FN add up to total."""
+        labels = [1, 1, 0, 0, 1, 0]
+        preds = [1, 0, 1, 0, 1, 0]
+        m = compute_metrics(labels, preds)
+        total = m["tp"] + m["fp"] + m["tn"] + m["fn"]
+        assert total == len(labels)
+
+
+# ======================================================================
+# Dataset split determinism
+# ======================================================================
+
+class TestDatasetSplit:
+    def test_split_is_deterministic(self):
+        """Same seed should produce identical splits."""
+        samples = [{"sample_id": i, "task": "qa"} for i in range(100)]
+        dev1, test1 = split_dev_test(samples, dev_ratio=0.7, seed=42)
+        dev2, test2 = split_dev_test(samples, dev_ratio=0.7, seed=42)
+        assert [s["sample_id"] for s in dev1] == [s["sample_id"] for s in dev2]
+        assert [s["sample_id"] for s in test1] == [s["sample_id"] for s in test2]
+
+    def test_split_ratio(self):
+        """Split should respect the dev_ratio."""
+        samples = [{"sample_id": i, "task": "qa"} for i in range(100)]
+        dev, test = split_dev_test(samples, dev_ratio=0.7, seed=42)
+        assert len(dev) == 70
+        assert len(test) == 30
+
+    def test_no_overlap(self):
+        """Dev and test sets should be disjoint."""
+        samples = [{"sample_id": i, "task": "qa"} for i in range(100)]
+        dev, test = split_dev_test(samples, dev_ratio=0.7, seed=42)
+        dev_ids = {s["sample_id"] for s in dev}
+        test_ids = {s["sample_id"] for s in test}
+        assert dev_ids & test_ids == set()  # no overlap
+        assert dev_ids | test_ids == set(range(100))  # complete coverage
+
+    def test_different_seeds_different_splits(self):
+        """Different seeds should produce different splits."""
+        samples = [{"sample_id": i, "task": "qa"} for i in range(100)]
+        dev1, _ = split_dev_test(samples, dev_ratio=0.7, seed=42)
+        dev2, _ = split_dev_test(samples, dev_ratio=0.7, seed=99)
+        ids1 = [s["sample_id"] for s in dev1]
+        ids2 = [s["sample_id"] for s in dev2]
+        assert ids1 != ids2
+
+
+# ======================================================================
+# CSV round-trip
+# ======================================================================
+
+class TestLoadPrecomputed:
+    def test_round_trip_v1(self, tmp_path):
+        """Write v1 CSV and load it back."""
+        import csv
+        from evaluate import FIELDNAMES_V1
+
+        path = tmp_path / "scores.csv"
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES_V1)
+            writer.writeheader()
+            writer.writerow({
+                "sample_id": 0, "task": "qa", "label": 1,
+                "retrieval_score": 0.85, "nli_score": 0.72,
+                "latency_ms": 15.5,
+            })
+
+        scores = load_precomputed(str(path))
+        assert len(scores) == 1
+        assert scores[0]["sample_id"] == 0
+        assert scores[0]["retrieval_score"] == 0.85
+        assert scores[0]["nli_score"] == 0.72
+        assert scores[0]["label"] == 1
+
+    def test_round_trip_v2(self, tmp_path):
+        """Write v2 CSV and load back with extra columns."""
+        import csv
+        from evaluate import FIELDNAMES_V2
+
+        path = tmp_path / "scores_v2.csv"
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES_V2)
+            writer.writeheader()
+            writer.writerow({
+                "sample_id": 0, "task": "qa", "label": 0,
+                "retrieval_score": 0.90, "nli_score": 0.65,
+                "nli_score_whole": 0.70, "nli_mean_score": 0.68,
+                "n_claims": 3, "n_windows": 5,
+                "nli_method": "decomposed", "latency_ms": 42.1,
+            })
+
+        scores = load_precomputed(str(path))
+        assert len(scores) == 1
+        assert scores[0]["nli_score_whole"] == 0.70
+        assert scores[0]["n_claims"] == 3
+        assert scores[0]["nli_method"] == "decomposed"
+
+    def test_v2_csv_backward_compatible(self, tmp_path):
+        """v1 CSV (missing v2 columns) should load without error."""
+        import csv
+        from evaluate import FIELDNAMES_V1
+
+        path = tmp_path / "scores_v1.csv"
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES_V1)
+            writer.writeheader()
+            writer.writerow({
+                "sample_id": 0, "task": "qa", "label": 1,
+                "retrieval_score": 0.5, "nli_score": 0.8,
+                "latency_ms": 10,
+            })
+
+        scores = load_precomputed(str(path))
+        # v2 fields should be absent (not error)
+        assert "nli_score_whole" not in scores[0]
+        assert scores[0]["nli_score"] == 0.8


### PR DESCRIPTION
## Summary

Adds a comprehensive pytest test suite with 75 tests. Fixes #33.

### Coverage

| Module | Tests | What's covered |
|--------|-------|----------------|
| **test_engine.py** | 32 | Tiered verdict (9 edge cases), continuous verdict (6), calibration guard (3), integration with real models (14, slow) |
| **test_api.py** | 14 | Health, knowledge-base, root, verify (v1/v2/offline/422/empty/invalid JSON/extra fields/rounding), CORS |
| **test_evaluate.py** | 29 | C1/C2/C3 condition logic (12), compute_metrics (7), dataset split determinism (4), CSV round-trip (3), alternate NLI key (1), multi-sample (1), error handling (1) |

### Running

```bash
make test       # fast unit tests (~4s, no model loading)
make test-all   # includes integration tests (~60s, loads models)
```

### Design decisions
- **`object.__new__(AFLHREngine)`** to test verdict logic without loading models (pure functions)
- **`@pytest.mark.slow`** for integration tests that need real model inference
- **Session-scoped engine fixtures** so models load only once across all slow tests
- **FastAPI `TestClient` with mocked engine** for API tests — no ML overhead

## Test plan

- [x] `make test` — 58 passed, 17 skipped, 0 failed (3.5s)
- [ ] `make test-all` — run with `--run-slow` to verify integration tests