### PR TITLE
Use venv for portable first-time setup

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,151 @@
+# FYP Submission Checklist
+
+**Module:** 6COSC023W - Computer Science Final Project
+**Weighting:** 70%
+**Deadline:** 30/03/2026 at 13:00 (no extensions)
+**Viva:** Date TBC by supervisor (1 hour, supervisor + moderator)
+
+All four elements (FPR + FPC + FVD + FPV) must be attempted for the FYP to be marked. They produce one combined mark.
+
+---
+
+## 1. Final Project Report (FPR) - 100% of report mark
+
+### Preliminary Sections (10% of report)
+
+- [ ] Cover page with actual project title (not placeholder)
+- [ ] Student name and supervisor name on title page
+- [ ] Declaration section completed (word count, name, date of submission)
+- [ ] Abstract summarising the entire project
+- [ ] Acknowledgements
+- [ ] Table of contents (correctly numbered, matches report structure)
+- [ ] List of figures (correctly numbered)
+- [ ] List of tables (correctly numbered)
+- [ ] All orange template sections deleted from final version
+- [ ] Structured writing style with clear connections across chapters
+- [ ] References — Harvard style, all cited sources listed
+- [ ] Bibliography — additional readings
+- [ ] Appendices (requirement data, evaluation data, key code, etc.)
+
+### Report Chapters (40% of report)
+
+- [ ] **Ch 1. Introduction**
+  - [ ] 1.1 Problem statement
+  - [ ] 1.2 Aims and objectives (clear, achievable)
+- [ ] **Ch 2. Background**
+  - [ ] 2.1 Literature survey
+  - [ ] 2.2 Review of projects/applications
+  - [ ] 2.3 Review of tools, frameworks and techniques
+  - [ ] Balanced evaluation of advantages/disadvantages, gaps identified
+- [ ] **Ch 3. Legal, Social and Ethical Issues**
+  - [ ] Legal, ethical, social, professional and security issues covered
+  - [ ] Issues related to software/data infrastructure and data collected/analysed
+- [ ] **Ch 4. Methodology**
+  - [ ] Critical review of methodology used
+  - [ ] Technical design solutions addressing requirements
+  - [ ] Contribution to knowledge/practice demonstrated
+- [ ] **Ch 8. Conclusions and Reflections**
+  - [ ] Conclusions on the resulting application
+  - [ ] New knowledge and skills acquired
+  - [ ] Further work to improve the application
+
+### Technical Chapters (50% of report)
+
+- [ ] **Ch 5. Design**
+  - [ ] Appropriate design methods used
+  - [ ] Diagrams/prototypes depicting the design
+  - [ ] Design follows requirements
+  - [ ] Originality demonstrated
+  - [ ] Design issues related to models/software/data infrastructure
+- [ ] **Ch 6. Tools and Implementation**
+  - [ ] 6.1 All tools listed with justification for why they were chosen
+  - [ ] 6.2 In-depth explanation of main code for key functions
+  - [ ] Clear indication of novel code vs adopted/adapted code with sources
+  - [ ] Critical evaluation if core functionality not implemented
+  - [ ] Originality clearly presented
+  - [ ] Demonstration of significant new technical skills gained
+  - [ ] Code executes without issues/errors
+- [ ] **Ch 7. Testing**
+  - [ ] 7.1 Functional testing (black box and/or white box)
+  - [ ] 7.2 User testing
+  - [ ] All results critically discussed
+  - [ ] Suggestions for further developments based on testing outcomes
+
+### Report Submission
+
+- [ ] File format: DOCX or PDF only (no other types)
+- [ ] File size under 10MB
+- [ ] NOT zipped
+- [ ] Demo video link included in Appendix I
+- [ ] Submit on Blackboard by deadline
+
+---
+
+## 2. Final Project Code (FPC)
+
+- [ ] Code is complete and functional
+- [ ] `make start` runs without errors
+- [ ] `make install` instructions work from clean checkout
+- [ ] README.md explains all steps to run the project
+- [ ] Code zipped for submission
+- [ ] If ZIP < 50MB: upload on Blackboard with report
+- [ ] If ZIP > 50MB: upload to University OneDrive, share link in Appendix I
+  - [ ] OneDrive sharing: "People in University of Westminster"
+  - [ ] "Block download" OFF
+  - [ ] Link pasted in Appendix I
+- [ ] GitHub repo link included in report/appendix
+- [ ] Access maintained until final grade confirmation (end of summer)
+
+---
+
+## 3. Final Project Video Demo (FVD)
+
+- [ ] Screen capture showing user interface
+- [ ] All functionalities demonstrated
+- [ ] How-to-use demonstration
+- [ ] Voiceover explaining/describing the product
+- [ ] Clear video and audio quality
+- [ ] Uploaded to OneDrive/YouTube/other platform
+- [ ] Link included in Appendix I of report
+- [ ] Link accessible until end of summer (grade confirmation)
+
+---
+
+## 4. Final Project Viva (FPV)
+
+- [ ] Prepared to demonstrate practical output live (1 hour)
+- [ ] Can explain the development process end-to-end
+- [ ] Understand wider context of the work
+- [ ] Ready to discuss relevant issues (ethical, legal, technical)
+- [ ] Can propose further work
+- [ ] `make start` tested and working for live demo
+
+---
+
+## Progress Summary (as of 2026-04-16)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| **FPR (Thesis)** | DONE | Completed thesis document |
+| **FPC (Code)** | DONE | Codebase finalized, reviewed, all PRs merged |
+| **FVD (Video)** | TODO | Screen capture with voiceover needed |
+| **FPV (Viva)** | TODO | Prepare for 1-hour oral exam, live demo |
+| **Submission** | TODO | Upload FPR + FPC + video link to Blackboard |
+
+### Code Status
+
+- Codebase reviewed and finalized (PR #30 merged)
+- Docs link added to frontend (PR #32 merged)
+- README with full setup instructions present
+- `make start` launches backend (:8000) + frontend (:5173) + docs (:4000)
+- All experiment results in `results/` directory
+- Docusaurus documentation site functional
+
+### Remaining Tasks
+
+1. **Record demo video** — screen capture of frontend (Verify, Explore, About pages), show v1 vs v2 mode, offline mode, threshold controls. Add voiceover.
+2. **Upload video** — OneDrive (UoW sharing) or YouTube, get shareable link
+3. **Final report check** — ensure video link is in Appendix I, declaration completed, orange sections removed, file < 10MB
+4. **Zip code** — zip entire project, check size for BB upload vs OneDrive
+5. **Submit on Blackboard** — FPR file + FPC zip (or OneDrive link) before 30/03/2026 13:00
+6. **Viva prep** — practice live demo, prepare to explain pipeline, methodology, results, further work

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -71,43 +71,58 @@ All four elements (FPR + FPC + FVD + FPV) must be attempted for the FYP to be ma
   - [ ] All results critically discussed
   - [ ] Suggestions for further developments based on testing outcomes
 
-### Report Submission
+### Report Pre-Submission Checks (from submission guide)
 
+- [ ] "Project Title" on title page replaced with actual title
+- [ ] Student name and supervisor name on title page
+- [ ] Declaration section completed (word count, name, date of submission)
+- [ ] ALL orange template sections deleted from final version
+- [ ] Demo video URL/link included in Appendix I
+- [ ] Code access link included in Appendix I (GitHub repo and/or OneDrive)
 - [ ] File format: DOCX or PDF only (no other types)
 - [ ] File size under 10MB
 - [ ] NOT zipped
-- [ ] Demo video link included in Appendix I
-- [ ] Submit on Blackboard by deadline
+- [ ] Submit on Blackboard together with FPC by 30/03/2026 13:00
 
 ---
 
 ## 2. Final Project Code (FPC)
 
+### Code Quality
 - [ ] Code is complete and functional
+- [ ] `make install` works from a clean checkout
 - [ ] `make start` runs without errors
-- [ ] `make install` instructions work from clean checkout
-- [ ] README.md explains all steps to run the project
-- [ ] Code zipped for submission
-- [ ] If ZIP < 50MB: upload on Blackboard with report
+- [ ] README.md explains all steps required to run the project
+- [ ] Code executes without issues and/or errors
+
+### Submission (from submission guide)
+- [ ] ZIP your entire code
+- [ ] If ZIP < 50MB: upload on Blackboard together with report
 - [ ] If ZIP > 50MB: upload to University OneDrive, share link in Appendix I
-  - [ ] OneDrive sharing: "People in University of Westminster"
+  - [ ] OneDrive sharing set to "People in University of Westminster"
   - [ ] "Block download" OFF
-  - [ ] Link pasted in Appendix I
-- [ ] GitHub repo link included in report/appendix
+  - [ ] Copy link and paste in Appendix I
+- [ ] If code is on external platform (GitHub): provide link and access
+  - [ ] Access granted to supervisor, moderator, and external examiners
+  - [ ] If password-protected, provide credentials
 - [ ] Access maintained until final grade confirmation (end of summer)
 
 ---
 
 ## 3. Final Project Video Demo (FVD)
 
-- [ ] Screen capture showing user interface
-- [ ] All functionalities demonstrated
-- [ ] How-to-use demonstration
-- [ ] Voiceover explaining/describing the product
+### Content Requirements
+- [ ] Screen capture showing the user interface
+- [ ] ALL functionalities demonstrated
+- [ ] Simple demonstration of how to use the software
+- [ ] Voiceover explaining/describing the product (required)
 - [ ] Clear video and audio quality
-- [ ] Uploaded to OneDrive/YouTube/other platform
-- [ ] Link included in Appendix I of report
-- [ ] Link accessible until end of summer (grade confirmation)
+
+### Submission (from submission guide)
+- [ ] Upload to OneDrive, YouTube, or other platform
+- [ ] Share link in Appendix I of the report
+- [ ] Verify the link is easily accessible (test in incognito/another browser)
+- [ ] Video must remain accessible until end of summer (grade confirmation)
 
 ---
 

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,0 +1,131 @@
+# AFLHR Lite - Video Demo Script
+
+**Target length:** 5-7 minutes
+**Format:** Screen capture with voiceover
+**Setup:** Run `make start` before recording. Have browser open to http://localhost:5173
+
+---
+
+## INTRO (30s)
+
+> "This is AFLHR Lite — a hallucination detection system built as my final year project. It uses a two-layer pipeline: RAG retrieval followed by NLI verification, with an adaptive threshold called Confidence-Weighted CONLI, or Cw-CONLI, that adjusts its scrutiny based on how confident the system is in the retrieved evidence."
+
+**On screen:** Show the landing page with the shield icon and "Verify a claim" prompt.
+
+---
+
+## 1. VERIFY PAGE — Basic Query (90s)
+
+> "Let me demonstrate the core functionality. I'll start with a straightforward question."
+
+**Action:** Click the suggested query "When was the University of Westminster founded?"
+
+> "The pipeline runs in four stages — you can see each one light up as it progresses. First, it retrieves relevant passages from the knowledge base using FAISS vector search. Then, it sends the query and context to Llama 3.1 via the Groq API to generate a response. Next, RoBERTa-large-MNLI performs Natural Language Inference to check whether the response is actually supported by the evidence. Finally, the adaptive verdict decides if the response is verified or a hallucination."
+
+**On screen:** Wait for results to appear. Point out the three result panels.
+
+> "On the left, you can see the retrieval confidence gauge and the retrieved passages. The retrieval score is above the pivot, so the system uses LENIENT mode — it trusts the evidence. In the middle is the LLM's generated response. On the right, the NLI entailment score and the verdict. The threshold bar shows where the NLI score sits relative to the threshold. This response is verified."
+
+---
+
+## 2. CONTROL PANEL — Threshold Adjustment (60s)
+
+> "What makes Cw-CONLI different from standard approaches is the adaptive threshold. Let me open the control panel to show how this works."
+
+**Action:** Open the Control Panel if collapsed. Adjust the sliders.
+
+> "There are three parameters. The pivot point determines where the system switches between strict and lenient mode. The strict threshold is applied when retrieval confidence is low — the system is sceptical. The lenient threshold is applied when retrieval is strong — the system trusts the evidence."
+
+**Action:** Drag the strict threshold higher (e.g. 0.99) to show the verdict flip.
+
+> "Watch what happens if I set a very high strict threshold — now even a well-supported response gets flagged. This demonstrates the core idea: the threshold is not hardcoded, it adapts to evidence quality."
+
+**Action:** Reset thresholds to defaults (Pivot: 0.75, Strict: 0.95, Lenient: 0.70).
+
+---
+
+## 3. v2 MODE — Claim Decomposition (60s)
+
+> "Version 2 of the pipeline adds three improvements. Let me enable v2 mode."
+
+**Action:** Check the "v2 Mode" checkbox in the control panel.
+
+> "v2 enables sliding-window NLI, which handles long documents that exceed RoBERTa's 512-token limit, sentence-level claim decomposition which verifies each claim independently, and an upgraded BGE embedding model."
+
+**Action:** Run a query like "What happened at the Royal Polytechnic Institution in 1896?" or type a multi-sentence claim.
+
+> "Now you can see the per-claim breakdown in the verification panel. Each sentence in the response is scored individually, and the system takes the minimum — a weakest-link approach. If even one claim is unsupported, the overall score drops. This catches partial hallucinations that whole-response NLI would miss."
+
+---
+
+## 4. OFFLINE MODE (30s)
+
+> "The system also works without an API key. Let me enable offline mode."
+
+**Action:** Check "Offline Mode" in the control panel. Run a query.
+
+> "In offline mode, the LLM generation is replaced with a mock response, but the RAG retrieval and NLI verification still run fully. This means the verification pipeline can be demonstrated and tested without any external API dependency."
+
+---
+
+## 5. EXPLORE PAGE — Batch Comparison (60s)
+
+**Action:** Navigate to the Explore page via the header.
+
+> "The Explore page runs multiple queries in batch to compare how the pipeline handles different scenarios."
+
+**Action:** Click "Run All Queries".
+
+> "There are seven pre-configured queries: three about the University of Westminster, two about AI hallucinations, one about Sri Lanka's climate which is a distractor topic in our knowledge base, and one completely off-topic question about the US president."
+
+**On screen:** Wait for results table to populate. Point out the stats bar.
+
+> "You can see the aggregate stats at the top — how many were verified versus flagged as hallucinations, and the average retrieval and NLI scores. The results table shows each query with its category, retrieval confidence, NLI score, and verdict. Notice how the off-topic query has a low retrieval score and gets flagged, while questions matching our knowledge base score highly."
+
+**Action:** Toggle v2 mode on and run again to show comparison.
+
+> "I can also toggle v2 mode here to compare the v1 and v2 pipelines side by side."
+
+---
+
+## 6. HOW IT WORKS PAGE (45s)
+
+**Action:** Navigate to the "How It Works" page.
+
+> "This page provides a visual walkthrough of the four-stage pipeline. Each stage shows the model used, its purpose, and the output it produces."
+
+**Action:** Scroll through the pipeline stages.
+
+> "It also explains the three threshold variants that were evaluated — tiered, square root, and sigmoid — showing their formulas and trade-offs. At the bottom is the technical stack: the embedding models, FAISS for vector search, RoBERTa for NLI, and Llama via Groq for generation."
+
+---
+
+## 7. THEME TOGGLE + DOCS (15s)
+
+**Action:** Click the theme toggle button in the header.
+
+> "The interface supports both dark and light themes, optimised for projector visibility."
+
+**Action:** Click the "Docs" link in the header.
+
+> "There's also a full documentation site with the API reference, architecture details, and experiment results."
+
+---
+
+## WRAP-UP (30s)
+
+**Action:** Navigate back to the Verify page.
+
+> "To summarise: AFLHR Lite is a two-layer hallucination detection pipeline where the verification threshold adapts based on retrieval confidence. Version 2 adds sliding-window NLI for long documents, claim decomposition for partial hallucinations, and BGE embeddings for better retrieval. The system was evaluated on 20,000 HaluEval samples and the results are documented in the thesis. Thank you for watching."
+
+---
+
+## Recording Tips
+
+- Use a clean browser window (no bookmarks bar, no other tabs)
+- Resolution: 1920x1080 or 2560x1440
+- Use dark theme for recording (more visually striking)
+- Speak slowly and clearly — voiceover is assessed
+- Keep mouse movements deliberate, don't rush between actions
+- Total target: 5-7 minutes (screen capture + voiceover is sufficient)
+- Tools: QuickTime Player (built-in Mac screen recording) or OBS

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PYTHON ?= $(shell command -v python3 2>/dev/null || echo python)
+VENV := venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
 PID_BACKEND := /tmp/aflhr_backend.pid
 PID_FRONTEND := /tmp/aflhr_frontend.pid
 PID_DOCS := /tmp/aflhr_docs.pid
@@ -6,21 +8,39 @@ BACKEND_PORT := 8000
 FRONTEND_PORT := 5173
 DOCS_PORT := 4000
 
-.PHONY: start stop restart status backend frontend install smoke help
+.PHONY: start stop restart status install smoke test test-all help
 
 # ── Default ────────────────────────────────────────────────────────────────────
 help:
 	@echo ""
+	@echo "  make install    Install all dependencies (creates venv)"
 	@echo "  make start      Start backend + frontend + docs"
 	@echo "  make stop       Stop backend + frontend + docs"
 	@echo "  make restart    Stop then start"
 	@echo "  make status     Show what's running"
-	@echo "  make install    Install all dependencies"
+	@echo "  make test       Run fast unit tests (~4s)"
+	@echo "  make test-all   Run all tests including slow integration (~60s)"
 	@echo "  make smoke      Smoke test (precompute 20 samples)"
+	@echo ""
+
+# ── Install ────────────────────────────────────────────────────────────────────
+install:
+	@echo "Creating Python virtual environment..."
+	@python3 -m venv $(VENV)
+	@echo "Installing Python dependencies..."
+	$(PIP) install -r requirements.txt
+	@echo "Installing frontend dependencies..."
+	cd frontend && npm install
+	@echo "Installing docs dependencies..."
+	cd docs && npm install
+	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
+	@echo ""
+	@echo "  ✓ Installation complete. Run: make start"
 	@echo ""
 
 # ── Start ──────────────────────────────────────────────────────────────────────
 start: stop
+	@if [ ! -f $(PYTHON) ]; then echo "Error: venv not found. Run 'make install' first." && exit 1; fi
 	@echo "Starting backend on port $(BACKEND_PORT)..."
 	@$(PYTHON) -m uvicorn api:app --port $(BACKEND_PORT) --log-level warning > /tmp/aflhr_backend.log 2>&1 & echo $$! > $(PID_BACKEND)
 	@echo "Waiting for backend (loading models, ~20s)..."
@@ -65,13 +85,13 @@ status:
 	@echo "--- Backend health ---"
 	@curl -sf http://localhost:$(BACKEND_PORT)/api/health 2>/dev/null || echo "  Backend unreachable"
 
-# ── Install ────────────────────────────────────────────────────────────────────
-install:
-	$(PYTHON) -m pip install -r requirements.txt
-	cd frontend && npm install
-	cd docs && npm install
-	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
-
 # ── Smoke test ─────────────────────────────────────────────────────────────────
 smoke:
 	$(PYTHON) evaluate.py --precompute --split dev --version v2 --limit 20
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+test:
+	$(PYTHON) -m pytest tests/ -v
+
+test-all:
+	$(PYTHON) -m pytest tests/ -v --run-slow

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A two-layer verification pipeline that combines Retrieval-Augmented Generation (
 ```bash
 git clone https://github.com/shaunyogeshwaran/Shaun_FYP.git
 cd Shaun_FYP
-make install        # installs pip + npm dependencies, creates .env
+make install        # creates venv, installs pip + npm dependencies, creates .env
 # Edit .env and add your GROQ_API_KEY (free at https://console.groq.com)
 make start          # starts backend (:8000) + frontend (:5173) + docs (:4000)
 ```
@@ -57,14 +57,9 @@ Open **http://localhost:5173** — that's it.
 | **GPU** | Optional — CUDA auto-detected, falls back to CPU. Colab notebook provided for faster GPU runs |
 | **Groq API key** | Optional — offline mode works without it (mock LLM responses; RAG + NLI verification still function) |
 
-### Custom Python path
+### How it works
 
-The Makefile auto-detects `python3`. To override:
-
-```bash
-PYTHON=/path/to/python3 make install
-PYTHON=/path/to/python3 make start
-```
+`make install` creates a Python virtual environment (`venv/`), installs all pip and npm dependencies into it, and copies `.env.example` to `.env`. All subsequent `make` commands use the venv Python automatically — no need to activate it manually or worry about which Python is on your PATH.
 
 ### Troubleshooting
 
@@ -87,17 +82,14 @@ If you prefer manual setup over `make install`:
    cd Shaun_FYP
    ```
 
-2. **Create a virtual environment (optional but recommended):**
+2. **Create a virtual environment and install dependencies:**
    ```bash
    python3 -m venv venv
    source venv/bin/activate  # macOS/Linux
    # or: venv\Scripts\activate  # Windows
-   ```
-
-3. **Install dependencies:**
-   ```bash
    pip install -r requirements.txt
    cd frontend && npm install && cd ..
+   cd docs && npm install && cd ..
    ```
 
 4. **Set up environment variables:**

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -25,15 +25,15 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.0.tgz",
-      "integrity": "sha512-alHFZ68/i9qLC/muEB07VQ9r7cB8AvCcGX6dVQi2PNHhc/ZQRmmFAv8KK1ay4UiseGSFr7f0nXBKsZ/jRg7e4g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
+      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -72,99 +72,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.0.tgz",
-      "integrity": "sha512-mfgUdLQNxOAvCZUGzPQxjahEWEPuQkKlV0ZtGmePOa9ZxIQZlk31vRBNbM6ScU8jTH41SCYE77G/lCifDr1SVw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
+      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.0.tgz",
-      "integrity": "sha512-5mjokeKYyPaP3Q8IYJEnutI+O4dW/Ixxx5IgsSxT04pCfGqPXxTOH311hTQxyNpcGGEOGrMv8n8Z+UMTPamioQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
+      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.0.tgz",
-      "integrity": "sha512-emtOvR6dl3rX3sBJXXbofMNHU1qMQqQSWu319RMrNL5BWoBqyiq7y0Zn6cjJm7aGHV/Qbf+KCCYeWNKEMPI3BQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
+      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.0.tgz",
-      "integrity": "sha512-IerGH2/hcj/6bwkpQg/HHRqmlGN1XwygQWythAk0gZFBrghs9danJaYuSS3ShzLSVoIVth4jY5GDPX9Lbw5cgg==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
+      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.0.tgz",
-      "integrity": "sha512-3idPJeXn5L0MmgP9jk9JJqblrQ/SguN93dNK9z9gfgyupBhHnJMOEjrRYcVgTIfvG13Y04wO+Q0FxE2Ut8PVbA==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
+      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.0.tgz",
-      "integrity": "sha512-q7qRoWrQK1a8m5EFQEmPlo7+pg9mVQ8X5jsChtChERre0uS2pdYEDixBBl0ydBSGkdGbLUDufcACIhH/077E4g==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
+      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.0.tgz",
-      "integrity": "sha512-Jc360x4yqb3eEg4OY4KEIdGePBxZogivKI+OGIU8aLXgAYPTECvzeOBc90312yHA1hr3AeRlAFl0rIc8lQaIrQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
+      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -177,81 +177,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.0.tgz",
-      "integrity": "sha512-OS3/Viao+NPpyBbEY3tf6hLewppG+UclD+9i0ju56mq2DrdMJFCkEky6Sk9S5VPcbLzxzg3BqBX6u9Q35w19aQ==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
+      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.0.tgz",
-      "integrity": "sha512-/znwgSiGufpbJVIoDmeQaHtTq+OMdDawFRbMSJVv+12n79hW+qdQXS8/Uu3BD3yn0BzgVFJEvrsHrCsInZKdhw==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
+      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.0.tgz",
-      "integrity": "sha512-dHjUfu4jfjdQiKDpCpAnM7LP5yfG0oNShtfpF5rMCel6/4HIoqJ4DC4h5GKDzgrvJYtgAhblo0AYBmOM00T+lQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
+      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.0.tgz",
-      "integrity": "sha512-bffIbUljAWnh/Ctu5uScORajuUavqmZ0ACYd1fQQeSSYA9NNN83ynO26pSc2dZRXpSK0fkc1//qSSFXMKGu+aw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
+      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.0.tgz",
-      "integrity": "sha512-y0EwNvPGvkM+yTAqqO6Gpt9wVGm3CLDtpLvNEiB3VGvN3WzfkjZGtLUsG/ru2kVJIIU7QcV0puuYgEpBeFxcJg==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
+      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.0.tgz",
-      "integrity": "sha512-xpwefe4fCOWnZgXCbkGpqQY6jgBSCf2hmgnySbyzZIccrv3SoashHKGPE4x6vVG+gdHrGciMTAcDo9HOZwH22Q==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
+      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.0"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -5395,12 +5395,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/prismjs": {
@@ -5875,25 +5875,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.0.tgz",
-      "integrity": "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
+      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.0",
-        "@algolia/client-abtesting": "5.50.0",
-        "@algolia/client-analytics": "5.50.0",
-        "@algolia/client-common": "5.50.0",
-        "@algolia/client-insights": "5.50.0",
-        "@algolia/client-personalization": "5.50.0",
-        "@algolia/client-query-suggestions": "5.50.0",
-        "@algolia/client-search": "5.50.0",
-        "@algolia/ingestion": "1.50.0",
-        "@algolia/monitoring": "1.50.0",
-        "@algolia/recommend": "5.50.0",
-        "@algolia/requester-browser-xhr": "5.50.0",
-        "@algolia/requester-fetch": "5.50.0",
-        "@algolia/requester-node-http": "5.50.0"
+        "@algolia/abtesting": "1.16.2",
+        "@algolia/client-abtesting": "5.50.2",
+        "@algolia/client-analytics": "5.50.2",
+        "@algolia/client-common": "5.50.2",
+        "@algolia/client-insights": "5.50.2",
+        "@algolia/client-personalization": "5.50.2",
+        "@algolia/client-query-suggestions": "5.50.2",
+        "@algolia/client-search": "5.50.2",
+        "@algolia/ingestion": "1.50.2",
+        "@algolia/monitoring": "1.50.2",
+        "@algolia/recommend": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -6067,9 +6067,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "funding": [
         {
           "type": "opencollective",
@@ -6086,8 +6086,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6193,9 +6193,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6318,9 +6318,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6439,14 +6439,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6529,9 +6529,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7258,9 +7258,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
-      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
       "license": "ISC",
       "engines": {
         "node": "^14 || ^16 || >=18"
@@ -8017,9 +8017,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.330",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
-      "integrity": "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==",
+      "version": "1.5.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8818,9 +8818,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10466,9 +10466,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -13036,9 +13036,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -13631,9 +13631,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -15364,24 +15364,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-fast-compare": {
@@ -15674,9 +15674,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -15985,11 +15985,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -16523,13 +16524,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17296,9 +17297,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17822,9 +17823,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -17843,9 +17844,8 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
@@ -18099,22 +18099,10 @@
       }
     },
     "node_modules/webpack/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -191,23 +191,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -749,9 +749,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -763,9 +763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -777,9 +777,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -805,9 +805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -819,9 +819,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -833,9 +833,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -847,9 +847,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -861,9 +861,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -875,9 +875,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -889,9 +889,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -903,9 +903,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -917,9 +917,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
@@ -931,9 +931,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -945,9 +945,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -959,9 +959,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -973,9 +973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -987,9 +987,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1001,9 +1001,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1015,9 +1015,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -1029,9 +1029,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -1043,9 +1043,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1057,9 +1057,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1071,9 +1071,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1085,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1205,11 +1205,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001779",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
-      "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.313",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+      "version": "1.5.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1495,9 +1495,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -1581,12 +1581,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.14.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1597,9 +1597,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1613,31 +1613,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },


### PR DESCRIPTION
## Summary

Fixes the "download and run" experience. Previously `make install` and `make start` used whatever `python3` was on PATH, which could be the wrong Python, missing packages, or wrong architecture. Now it creates an isolated venv automatically.

### Changes

- **Makefile**: `make install` creates a `venv/`, installs all pip deps into it. `make start` uses `venv/bin/python` and checks it exists first.
- **README**: Updated Quick Start, "How it works" section, and manual install steps to reflect the venv flow.

### Before (broken on fresh machine)
```
make install   # uses system python3 — might not have deps, wrong arch
make start     # fails with ImportError or architecture mismatch
```

### After (works on any machine)
```
make install   # creates venv, installs everything isolated
make start     # uses venv python — guaranteed correct deps
```

## Test plan

- [ ] Delete `venv/` if it exists, run `make install` — should create venv and install all deps
- [ ] `make start` — backend, frontend, and docs all launch
- [ ] `make start` without `make install` — should print "Error: venv not found" and exit
- [ ] `make stop` — kills all processes cleanly