### PR TITLE
Use venv for portable first-time setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PYTHON ?= $(shell command -v python3 2>/dev/null || echo python)
+VENV := venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
 PID_BACKEND := /tmp/aflhr_backend.pid
 PID_FRONTEND := /tmp/aflhr_frontend.pid
 PID_DOCS := /tmp/aflhr_docs.pid
@@ -6,21 +8,39 @@ BACKEND_PORT := 8000
 FRONTEND_PORT := 5173
 DOCS_PORT := 4000
 
-.PHONY: start stop restart status backend frontend install smoke help
+.PHONY: start stop restart status install smoke test test-all help
 
 # ── Default ────────────────────────────────────────────────────────────────────
 help:
 	@echo ""
+	@echo "  make install    Install all dependencies (creates venv)"
 	@echo "  make start      Start backend + frontend + docs"
 	@echo "  make stop       Stop backend + frontend + docs"
 	@echo "  make restart    Stop then start"
 	@echo "  make status     Show what's running"
-	@echo "  make install    Install all dependencies"
+	@echo "  make test       Run fast unit tests (~4s)"
+	@echo "  make test-all   Run all tests including slow integration (~60s)"
 	@echo "  make smoke      Smoke test (precompute 20 samples)"
+	@echo ""
+
+# ── Install ────────────────────────────────────────────────────────────────────
+install:
+	@echo "Creating Python virtual environment..."
+	@python3 -m venv $(VENV)
+	@echo "Installing Python dependencies..."
+	$(PIP) install -r requirements.txt
+	@echo "Installing frontend dependencies..."
+	cd frontend && npm install
+	@echo "Installing docs dependencies..."
+	cd docs && npm install
+	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
+	@echo ""
+	@echo "  ✓ Installation complete. Run: make start"
 	@echo ""
 
 # ── Start ──────────────────────────────────────────────────────────────────────
 start: stop
+	@if [ ! -f $(PYTHON) ]; then echo "Error: venv not found. Run 'make install' first." && exit 1; fi
 	@echo "Starting backend on port $(BACKEND_PORT)..."
 	@$(PYTHON) -m uvicorn api:app --port $(BACKEND_PORT) --log-level warning > /tmp/aflhr_backend.log 2>&1 & echo $$! > $(PID_BACKEND)
 	@echo "Waiting for backend (loading models, ~20s)..."
@@ -65,13 +85,13 @@ status:
 	@echo "--- Backend health ---"
 	@curl -sf http://localhost:$(BACKEND_PORT)/api/health 2>/dev/null || echo "  Backend unreachable"
 
-# ── Install ────────────────────────────────────────────────────────────────────
-install:
-	$(PYTHON) -m pip install -r requirements.txt
-	cd frontend && npm install
-	cd docs && npm install
-	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
-
 # ── Smoke test ─────────────────────────────────────────────────────────────────
 smoke:
 	$(PYTHON) evaluate.py --precompute --split dev --version v2 --limit 20
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+test:
+	$(PYTHON) -m pytest tests/ -v
+
+test-all:
+	$(PYTHON) -m pytest tests/ -v --run-slow

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A two-layer verification pipeline that combines Retrieval-Augmented Generation (
 ```bash
 git clone https://github.com/shaunyogeshwaran/Shaun_FYP.git
 cd Shaun_FYP
-make install        # installs pip + npm dependencies, creates .env
+make install        # creates venv, installs pip + npm dependencies, creates .env
 # Edit .env and add your GROQ_API_KEY (free at https://console.groq.com)
 make start          # starts backend (:8000) + frontend (:5173) + docs (:4000)
 ```
@@ -57,14 +57,9 @@ Open **http://localhost:5173** — that's it.
 | **GPU** | Optional — CUDA auto-detected, falls back to CPU. Colab notebook provided for faster GPU runs |
 | **Groq API key** | Optional — offline mode works without it (mock LLM responses; RAG + NLI verification still function) |
 
-### Custom Python path
+### How it works
 
-The Makefile auto-detects `python3`. To override:
-
-```bash
-PYTHON=/path/to/python3 make install
-PYTHON=/path/to/python3 make start
-```
+`make install` creates a Python virtual environment (`venv/`), installs all pip and npm dependencies into it, and copies `.env.example` to `.env`. All subsequent `make` commands use the venv Python automatically — no need to activate it manually or worry about which Python is on your PATH.
 
 ### Troubleshooting
 
@@ -87,17 +82,14 @@ If you prefer manual setup over `make install`:
    cd Shaun_FYP
    ```
 
-2. **Create a virtual environment (optional but recommended):**
+2. **Create a virtual environment and install dependencies:**
    ```bash
    python3 -m venv venv
    source venv/bin/activate  # macOS/Linux
    # or: venv\Scripts\activate  # Windows
-   ```
-
-3. **Install dependencies:**
-   ```bash
    pip install -r requirements.txt
    cd frontend && npm install && cd ..
+   cd docs && npm install && cd ..
    ```
 
 4. **Set up environment variables:**


### PR DESCRIPTION
## Summary

Fixes the "clone and run" experience. Previously `make install` and `make start` used whatever `python3` was on PATH, which could be the wrong Python, missing packages, or wrong architecture. Now it creates an isolated venv automatically.

### Changes

- **Makefile**: `make install` creates a `venv/`, installs all pip deps into it. `make start` uses `venv/bin/python` and checks it exists first. Added `make test` and `make test-all` targets.
- **README**: Updated Quick Start, added "How it works" section, updated manual install steps.

### Before
```
make install   # uses system python3 — might fail on wrong arch/missing deps
make start     # ImportError or architecture mismatch
```

### After
```
make install   # creates venv, installs everything isolated
make start     # uses venv python — guaranteed correct deps
```

## Test plan

- [ ] Delete `venv/` if it exists, run `make install` — creates venv and installs all deps
- [ ] `make start` — backend, frontend, and docs all launch
- [ ] `make start` without `make install` — prints "Error: venv not found" and exits
- [ ] `make stop` — kills all processes cleanly