### PR TITLE
Auto-install Node.js — only Python needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 VENV := venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
+NPM := $(VENV)/bin/npm
+NPX := $(VENV)/bin/npx
+NODE_VERSION := 20.18.0
 PID_BACKEND := /tmp/aflhr_backend.pid
 PID_FRONTEND := /tmp/aflhr_frontend.pid
 PID_DOCS := /tmp/aflhr_docs.pid
@@ -13,7 +16,7 @@ DOCS_PORT := 4000
 # ── Default ────────────────────────────────────────────────────────────────────
 help:
 	@echo ""
-	@echo "  make install    Install all dependencies (creates venv)"
+	@echo "  make install    Install everything (Python venv + Node.js + all deps)"
 	@echo "  make start      Start backend + frontend + docs"
 	@echo "  make stop       Stop backend + frontend + docs"
 	@echo "  make restart    Stop then start"
@@ -22,29 +25,26 @@ help:
 	@echo "  make test-all   Run all tests including slow integration (~60s)"
 	@echo "  make smoke      Smoke test (precompute 20 samples)"
 	@echo ""
+	@echo "  Prerequisites: Python 3.10+ and make (Node.js is installed automatically)"
+	@echo ""
 
 # ── Install ────────────────────────────────────────────────────────────────────
 install:
 	@echo "Checking prerequisites..."
 	@command -v python3 >/dev/null 2>&1 || (echo "Error: python3 not found. Install Python 3.10+ first." && exit 1)
-	@command -v node >/dev/null 2>&1 || (echo "Error: node not found. Install Node.js 20+ first." && exit 1)
-	@command -v npm >/dev/null 2>&1 || (echo "Error: npm not found. Install Node.js 20+ first." && exit 1)
-	@NODE_MAJOR=$$(node -e "console.log(process.version.split('.')[0].slice(1))"); \
-		if [ "$$NODE_MAJOR" -lt 20 ]; then \
-			echo "Error: Node.js >= 20 required (found $$(node --version)). Update at https://nodejs.org"; \
-			exit 1; \
-		fi
-	@echo "Fixing npm cache permissions..."
-	@mkdir -p ~/.npm && chown -R $$(whoami) ~/.npm 2>/dev/null || true
 	@echo "Creating Python virtual environment..."
 	python3 -m venv $(VENV)
-	@echo "Installing Python dependencies..."
+	@echo "Upgrading pip..."
 	$(PIP) install --upgrade pip
+	@echo "Installing Node.js $(NODE_VERSION) into venv (via nodeenv)..."
+	$(PIP) install nodeenv
+	$(PYTHON) -m nodeenv --node=$(NODE_VERSION) --python-virtualenv --prebuilt $(VENV)
+	@echo "Installing Python dependencies..."
 	$(PIP) install -r requirements.txt
 	@echo "Installing frontend dependencies..."
-	cd frontend && rm -rf node_modules && npm cache clean --force 2>/dev/null; npm install --no-fund --no-audit
+	cd frontend && rm -rf node_modules && $(NPM) install --no-fund --no-audit
 	@echo "Installing docs dependencies..."
-	cd docs && rm -rf node_modules && npm cache clean --force 2>/dev/null; npm install --no-fund --no-audit
+	cd docs && rm -rf node_modules && $(NPM) install --no-fund --no-audit
 	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
 	@echo ""
 	@echo "  ✓ Installation complete. Run: make start"
@@ -62,13 +62,13 @@ start: stop
 		[ $$i -eq 30 ] && echo "  ✗ Backend failed — check: tail /tmp/aflhr_backend.log"; \
 	done
 	@echo "Starting frontend on port $(FRONTEND_PORT)..."
-	@cd frontend && npm run dev -- --port $(FRONTEND_PORT) --strictPort > /tmp/aflhr_frontend.log 2>&1 & echo $$! > $(PID_FRONTEND)
+	@cd frontend && $(NPM) run dev -- --port $(FRONTEND_PORT) --strictPort > /tmp/aflhr_frontend.log 2>&1 & echo $$! > $(PID_FRONTEND)
 	@sleep 4
 	@grep -q "Local:" /tmp/aflhr_frontend.log \
 		&& echo "  ✓ Frontend ready" \
 		|| (echo "  ✗ Frontend failed — check: tail /tmp/aflhr_frontend.log" && cat /tmp/aflhr_frontend.log)
 	@echo "Starting docs on port $(DOCS_PORT)..."
-	@cd docs && npx docusaurus start --port $(DOCS_PORT) --no-open > /tmp/aflhr_docs.log 2>&1 & echo $$! > $(PID_DOCS)
+	@cd docs && $(NPX) docusaurus start --port $(DOCS_PORT) --no-open > /tmp/aflhr_docs.log 2>&1 & echo $$! > $(PID_DOCS)
 	@sleep 4
 	@curl -sf http://localhost:$(DOCS_PORT) > /dev/null 2>&1 \
 		&& echo "  ✓ Docs ready" \

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ A two-layer verification pipeline that combines Retrieval-Augmented Generation (
 
 ## Prerequisites
 
-- Python 3.10+
-- Node.js 20+ (for frontend and docs)
+- Python 3.10+ and make (Node.js 20 is installed automatically by `make install`)
 - 24 GB RAM recommended
 - GPU auto-detected (CUDA used when available; falls back to CPU on Mac/other). Colab notebook provided for faster GPU runs
 
@@ -50,8 +49,8 @@ Open **http://localhost:5173** — that's it.
 
 | Requirement | Details |
 |---|---|
-| **Python** | 3.10+ with pip |
-| **Node.js** | 20+ with npm (required by react-router and Docusaurus) |
+| **Python** | 3.10+ with pip (only prerequisite) |
+| **Node.js** | 20+ (installed automatically by `make install` via nodeenv) |
 | **RAM** | 24 GB recommended (ML models load into memory) |
 | **Disk** | ~3 GB (models auto-download from HuggingFace on first run) |
 | **GPU** | Optional — CUDA auto-detected, falls back to CPU. Colab notebook provided for faster GPU runs |
@@ -59,7 +58,7 @@ Open **http://localhost:5173** — that's it.
 
 ### How it works
 
-`make install` creates a Python virtual environment (`venv/`), installs all pip and npm dependencies into it, and copies `.env.example` to `.env`. All subsequent `make` commands use the venv Python automatically — no need to activate it manually or worry about which Python is on your PATH.
+`make install` creates a Python virtual environment (`venv/`), installs Node.js 20 into it via `nodeenv`, then installs all pip and npm dependencies. Everything lives inside `venv/` — no global installs, no PATH issues, no permission errors. All subsequent `make` commands use the venv's Python, Node, and npm automatically.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary

Eliminates Node.js as a prerequisite. `make install` now automatically installs Node.js 20 into the Python venv using `nodeenv`. The only thing someone needs on their machine is **Python 3.10+ and make**.

### How it works
1. `make install` creates a Python venv
2. Installs `nodeenv` via pip
3. `nodeenv` downloads a prebuilt Node.js 20.18.0 binary into `venv/bin/`
4. All `npm`/`npx` commands use `venv/bin/npm` — no global Node needed
5. No EACCES errors, no version mismatches, no PATH issues

### Before
- Required Python 3.10+ AND Node.js 20+ installed separately
- npm EACCES errors on machines with corrupted cache
- Node version mismatches (18 vs 20)

### After
```bash
git clone https://github.com/shaunyogeshwaran/Shaun_FYP.git
cd Shaun_FYP
make install    # installs Python deps + Node.js 20 + npm deps — all in venv/
make start      # just works
```

## Test plan
- [ ] Fresh clone on a Mac with only Python — `make install && make start` works
- [ ] Machine with no Node.js installed — still works
- [ ] Machine with Node 18 — venv uses its own Node 20, ignores system Node