### PR TITLE
Fix SSL cert error on fresh macOS Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,12 @@ install:
 	@command -v python3 >/dev/null 2>&1 || (echo "Error: python3 not found. Install Python 3.10+ first." && exit 1)
 	@echo "Creating Python virtual environment..."
 	python3 -m venv $(VENV)
-	@echo "Upgrading pip..."
-	$(PIP) install --upgrade pip
+	@echo "Upgrading pip and fixing SSL certificates..."
+	$(PIP) install --upgrade pip certifi
 	@echo "Installing Node.js $(NODE_VERSION) into venv (via nodeenv)..."
 	$(PIP) install nodeenv
-	$(PYTHON) -m nodeenv --node=$(NODE_VERSION) --python-virtualenv --prebuilt $(VENV)
+	SSL_CERT_FILE=$$($(PYTHON) -c "import certifi; print(certifi.where())") \
+		$(PYTHON) -m nodeenv --node=$(NODE_VERSION) --python-virtualenv --prebuilt $(VENV)
 	@echo "Installing Python dependencies..."
 	$(PIP) install -r requirements.txt
 	@echo "Installing frontend dependencies..."


### PR DESCRIPTION
## Summary

Fixes `SSL: CERTIFICATE_VERIFY_FAILED` error when `make install` tries to download Node.js via nodeenv on a fresh macOS Python install.

### Root cause
macOS Python from python.org ships without SSL root certificates. The `Install Certificates.command` bundled with the installer is supposed to fix this, but most people don't run it.

### Fix
Install `certifi` via pip (which bundles Mozilla's root certs), then set `SSL_CERT_FILE` to point to certifi's cert bundle before running nodeenv. Fully automatic — no manual steps needed.

## Test plan
- [ ] Fresh macOS with python.org Python (no certs installed) — `make install` works
- [ ] Mac with certs already installed — still works (certifi is harmless)