### PR TITLE
Fix npm path when cd into subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VENV := venv
+VENV := $(CURDIR)/venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 NPM := $(VENV)/bin/npm


### PR DESCRIPTION
## Summary

`venv/bin/npm` was a relative path that broke when Makefile cd'd into `frontend/` or `docs/`. Changed `VENV` to use `$(CURDIR)/venv` so all paths are absolute.

## Test plan
- [ ] `make install` completes — npm install works in both frontend/ and docs/
- [ ] `make start` — frontend and docs launch using venv's node/npm