### PR TITLE
Auto-find free ports — no more port conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,7 @@ PIP := $(VENV)/bin/pip
 NPM := $(VENV)/bin/npm
 NPX := $(VENV)/bin/npx
 NODE_VERSION := 20.18.0
-PID_BACKEND := /tmp/aflhr_backend.pid
-PID_FRONTEND := /tmp/aflhr_frontend.pid
-PID_DOCS := /tmp/aflhr_docs.pid
-BACKEND_PORT := 8000
-FRONTEND_PORT := 5173
-DOCS_PORT := 4000
+NODE_ENV_VARS := PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache
 
 .PHONY: start stop restart status install smoke test test-all help
 
@@ -43,60 +38,38 @@ install:
 	@echo "Installing Python dependencies..."
 	$(PIP) install -r requirements.txt
 	@echo "Installing frontend dependencies..."
-	cd frontend && rm -rf node_modules && PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache $(NPM) install --no-fund --no-audit
+	cd frontend && rm -rf node_modules && $(NODE_ENV_VARS) $(NPM) install --no-fund --no-audit
 	@echo "Installing docs dependencies..."
-	cd docs && rm -rf node_modules && PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache $(NPM) install --no-fund --no-audit
+	cd docs && rm -rf node_modules && $(NODE_ENV_VARS) $(NPM) install --no-fund --no-audit
 	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
 	@echo ""
 	@echo "  ✓ Installation complete. Run: make start"
 	@echo ""
 
 # ── Start ──────────────────────────────────────────────────────────────────────
-start: stop
+start:
 	@if [ ! -f $(PYTHON) ]; then echo "Error: venv not found. Run 'make install' first." && exit 1; fi
-	@echo "Starting backend on port $(BACKEND_PORT)..."
-	@$(PYTHON) -m uvicorn api:app --port $(BACKEND_PORT) --log-level warning > /tmp/aflhr_backend.log 2>&1 & echo $$! > $(PID_BACKEND)
-	@echo "Waiting for backend (loading models, ~20s)..."
-	@for i in $$(seq 1 30); do \
-		sleep 2; \
-		curl -sf http://localhost:$(BACKEND_PORT)/api/health > /dev/null 2>&1 && echo "  ✓ Backend ready" && break; \
-		[ $$i -eq 30 ] && echo "  ✗ Backend failed — check: tail /tmp/aflhr_backend.log"; \
-	done
-	@echo "Starting frontend on port $(FRONTEND_PORT)..."
-	@cd frontend && PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache $(NPM) run dev -- --port $(FRONTEND_PORT) --strictPort > /tmp/aflhr_frontend.log 2>&1 & echo $$! > $(PID_FRONTEND)
-	@sleep 4
-	@grep -q "Local:" /tmp/aflhr_frontend.log \
-		&& echo "  ✓ Frontend ready" \
-		|| (echo "  ✗ Frontend failed — check: tail /tmp/aflhr_frontend.log" && cat /tmp/aflhr_frontend.log)
-	@echo "Starting docs on port $(DOCS_PORT)..."
-	@cd docs && PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache $(NPX) docusaurus start --port $(DOCS_PORT) --no-open > /tmp/aflhr_docs.log 2>&1 & echo $$! > $(PID_DOCS)
-	@sleep 4
-	@curl -sf http://localhost:$(DOCS_PORT) > /dev/null 2>&1 \
-		&& echo "  ✓ Docs ready" \
-		|| echo "  ✗ Docs failed — check: tail /tmp/aflhr_docs.log"
-	@echo ""
-	@echo "  → App:  http://localhost:$(FRONTEND_PORT)"
-	@echo "  → Docs: http://localhost:$(DOCS_PORT)"
-	@echo "  → API:  http://localhost:$(BACKEND_PORT)/docs"
-	@echo ""
+	@$(PYTHON) start.py
 
 # ── Stop ───────────────────────────────────────────────────────────────────────
 stop:
-	@pkill -f "uvicorn api:app" 2>/dev/null && echo "Stopped backend" || true
-	@kill $$(cat $(PID_FRONTEND) 2>/dev/null) 2>/dev/null && echo "Stopped frontend" || true
-	@kill $$(cat $(PID_DOCS) 2>/dev/null) 2>/dev/null && echo "Stopped docs" || true
-	@rm -f $(PID_BACKEND) $(PID_FRONTEND) $(PID_DOCS)
-	@sleep 2
+	@$(PYTHON) -c "import start; start.stop()" 2>/dev/null || true
+	@pkill -f "uvicorn api:app" 2>/dev/null || true
+	@sleep 1
 
 # ── Restart ────────────────────────────────────────────────────────────────────
 restart: stop start
 
 # ── Status ─────────────────────────────────────────────────────────────────────
 status:
-	@echo "--- Ports ---"
-	@lsof -i :$(BACKEND_PORT) -i :$(FRONTEND_PORT) -i :$(DOCS_PORT) -P 2>/dev/null | grep LISTEN || echo "  Nothing running"
-	@echo "--- Backend health ---"
-	@curl -sf http://localhost:$(BACKEND_PORT)/api/health 2>/dev/null || echo "  Backend unreachable"
+	@if [ -f /tmp/aflhr_pids.txt ]; then \
+		echo "--- Running PIDs ---"; \
+		cat /tmp/aflhr_pids.txt; \
+		echo "--- Processes ---"; \
+		while read pid; do ps -p $$pid -o pid,command 2>/dev/null | tail -1; done < /tmp/aflhr_pids.txt; \
+	else \
+		echo "  Nothing running (no PID file found)"; \
+	fi
 
 # ── Smoke test ─────────────────────────────────────────────────────────────────
 smoke:

--- a/start.py
+++ b/start.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Start all AFLHR Lite services on available ports."""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+VENV = os.path.join(os.path.dirname(os.path.abspath(__file__)), "venv")
+PYTHON = os.path.join(VENV, "bin", "python")
+NPM = os.path.join(VENV, "bin", "npm")
+NPX = os.path.join(VENV, "bin", "npx")
+PID_FILE = "/tmp/aflhr_pids.txt"
+
+# Preferred ports (will auto-increment if busy)
+PREFERRED = {"backend": 8000, "frontend": 5173, "docs": 4000}
+
+
+def find_free_port(start):
+    """Find the next free port starting from `start`."""
+    port = start
+    while port < start + 100:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                port += 1
+    print(f"Error: no free port found in range {start}-{start+99}")
+    sys.exit(1)
+
+
+def wait_for_port(port, timeout=60):
+    """Wait until a port is accepting connections."""
+    start = time.time()
+    while time.time() - start < timeout:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(2)
+    return False
+
+
+def stop():
+    """Kill any previously started services."""
+    if os.path.exists(PID_FILE):
+        with open(PID_FILE) as f:
+            for line in f:
+                pid = line.strip()
+                if pid:
+                    try:
+                        os.kill(int(pid), signal.SIGTERM)
+                    except (ProcessLookupError, ValueError):
+                        pass
+        os.remove(PID_FILE)
+
+    # Also kill by name as fallback
+    for pattern in ["uvicorn api:app"]:
+        subprocess.run(["pkill", "-f", pattern],
+                       capture_output=True)
+    time.sleep(1)
+
+
+def main():
+    if not os.path.exists(PYTHON):
+        print("Error: venv not found. Run 'make install' first.")
+        sys.exit(1)
+
+    env = os.environ.copy()
+    env["PATH"] = os.path.join(VENV, "bin") + ":" + env.get("PATH", "")
+    env["npm_config_cache"] = os.path.join(VENV, ".npm-cache")
+
+    # Stop previous instances
+    stop()
+
+    pids = []
+
+    # --- Backend ---
+    bp = find_free_port(PREFERRED["backend"])
+    print(f"Starting backend on port {bp}...")
+    backend = subprocess.Popen(
+        [PYTHON, "-m", "uvicorn", "api:app", "--port", str(bp),
+         "--log-level", "warning"],
+        stdout=open("/tmp/aflhr_backend.log", "w"),
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    pids.append(backend.pid)
+
+    print("Waiting for backend (loading models, ~20s)...")
+    if wait_for_port(bp, timeout=60):
+        print(f"  ✓ Backend ready on port {bp}")
+    else:
+        print(f"  ✗ Backend failed — check: tail /tmp/aflhr_backend.log")
+
+    # --- Frontend ---
+    fp = find_free_port(PREFERRED["frontend"])
+    print(f"Starting frontend on port {fp}...")
+
+    # Write VITE_API_URL so frontend knows where the backend is
+    env["VITE_API_URL"] = f"http://localhost:{bp}"
+
+    frontend = subprocess.Popen(
+        [NPM, "run", "dev", "--", "--port", str(fp), "--strictPort"],
+        cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), "frontend"),
+        stdout=open("/tmp/aflhr_frontend.log", "w"),
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    pids.append(frontend.pid)
+
+    if wait_for_port(fp, timeout=15):
+        print(f"  ✓ Frontend ready on port {fp}")
+    else:
+        print(f"  ✗ Frontend failed — check: tail /tmp/aflhr_frontend.log")
+
+    # --- Docs ---
+    dp = find_free_port(PREFERRED["docs"])
+    print(f"Starting docs on port {dp}...")
+    docs = subprocess.Popen(
+        [NPX, "docusaurus", "start", "--port", str(dp), "--no-open"],
+        cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), "docs"),
+        stdout=open("/tmp/aflhr_docs.log", "w"),
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    pids.append(docs.pid)
+
+    if wait_for_port(dp, timeout=15):
+        print(f"  ✓ Docs ready on port {dp}")
+    else:
+        print(f"  ✗ Docs failed — check: tail /tmp/aflhr_docs.log")
+
+    # Save PIDs for stop
+    with open(PID_FILE, "w") as f:
+        for pid in pids:
+            f.write(f"{pid}\n")
+
+    print()
+    print(f"  → App:  http://localhost:{fp}")
+    print(f"  → Docs: http://localhost:{dp}")
+    print(f"  → API:  http://localhost:{bp}/docs")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Replaces hardcoded ports with `start.py` that automatically finds free ports. No more "port already in use" errors.

### How it works
- Tries preferred ports (8000, 5173, 4000)
- If busy, increments until it finds a free one
- Sets `VITE_API_URL` dynamically so frontend connects to the correct backend port
- Saves PIDs to `/tmp/aflhr_pids.txt` for clean `make stop`
- `make start` just works regardless of what's running on the machine

### Before
```
Port 5173 is already in use  ← stale process from previous run
```

### After
```
Starting backend on port 8000...
  ✓ Backend ready on port 8000
Starting frontend on port 5174...    ← auto-found next free port
  ✓ Frontend ready on port 5174
```

## Test plan
- [ ] `make install && make start` on fresh machine
- [ ] `make start` twice without `make stop` — second run finds new ports
- [ ] `make stop` kills all services cleanly