### PR TITLE
Host docs on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [docs/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install and build docs
+        working-directory: docs
+        run: |
+          npm install --no-fund --no-audit
+          DOCS_URL=https://shaunyogeshwaran.github.io BASE_URL=/Shaun_FYP/ npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ VENV := $(CURDIR)/venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 NPM := $(VENV)/bin/npm
-NPX := $(VENV)/bin/npx
 NODE_VERSION := 20.18.0
 NODE_ENV_VARS := PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache
 
@@ -12,8 +11,8 @@ NODE_ENV_VARS := PATH=$(VENV)/bin:$$PATH npm_config_cache=$(VENV)/.npm-cache
 help:
 	@echo ""
 	@echo "  make install    Install everything (Python venv + Node.js + all deps)"
-	@echo "  make start      Start backend + frontend + docs"
-	@echo "  make stop       Stop backend + frontend + docs"
+	@echo "  make start      Start backend + frontend"
+	@echo "  make stop       Stop backend + frontend"
 	@echo "  make restart    Stop then start"
 	@echo "  make status     Show what's running"
 	@echo "  make test       Run fast unit tests (~4s)"
@@ -39,8 +38,6 @@ install:
 	$(PIP) install -r requirements.txt
 	@echo "Installing frontend dependencies..."
 	cd frontend && rm -rf node_modules && $(NODE_ENV_VARS) $(NPM) install --no-fund --no-audit
-	@echo "Installing docs dependencies..."
-	cd docs && rm -rf node_modules && $(NODE_ENV_VARS) $(NPM) install --no-fund --no-audit
 	@cp -n .env.example .env 2>/dev/null && echo "Created .env — add your GROQ_API_KEY" || echo ".env already exists, skipping"
 	@echo ""
 	@echo "  ✓ Installation complete. Run: make start"

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   future: { v4: true },
 
   url: process.env.DOCS_URL || 'http://localhost:4000',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL || '/',
 
   onBrokenLinks: 'warn',
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,7 +5,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { useTheme } from '../ThemeContext'
 import { fonts } from '../styles/theme'
 
-const DOCS_URL = import.meta.env.VITE_DOCS_URL || 'http://localhost:4000'
+const DOCS_URL = import.meta.env.VITE_DOCS_URL || 'https://shaunyogeshwaran.github.io/Shaun_FYP/'
 
 const navItems = [
   { path: '/', label: 'Verify' },

--- a/start.py
+++ b/start.py
@@ -11,11 +11,11 @@ import time
 VENV = os.path.join(os.path.dirname(os.path.abspath(__file__)), "venv")
 PYTHON = os.path.join(VENV, "bin", "python")
 NPM = os.path.join(VENV, "bin", "npm")
-NPX = os.path.join(VENV, "bin", "npx")
 PID_FILE = "/tmp/aflhr_pids.txt"
+DOCS_URL = "https://shaunyogeshwaran.github.io/Shaun_FYP/"
 
 # Preferred ports (will auto-increment if busy)
-PREFERRED = {"backend": 8000, "frontend": 5173, "docs": 4000}
+PREFERRED = {"backend": 8000, "frontend": 5173}
 
 
 def find_free_port(start):
@@ -116,23 +116,6 @@ def main():
     else:
         print(f"  ✗ Frontend failed — check: tail /tmp/aflhr_frontend.log")
 
-    # --- Docs ---
-    dp = find_free_port(PREFERRED["docs"])
-    print(f"Starting docs on port {dp}...")
-    docs = subprocess.Popen(
-        [NPX, "docusaurus", "start", "--port", str(dp), "--no-open"],
-        cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), "docs"),
-        stdout=open("/tmp/aflhr_docs.log", "w"),
-        stderr=subprocess.STDOUT,
-        env=env,
-    )
-    pids.append(docs.pid)
-
-    if wait_for_port(dp, timeout=15):
-        print(f"  ✓ Docs ready on port {dp}")
-    else:
-        print(f"  ✗ Docs failed — check: tail /tmp/aflhr_docs.log")
-
     # Save PIDs for stop
     with open(PID_FILE, "w") as f:
         for pid in pids:
@@ -140,8 +123,8 @@ def main():
 
     print()
     print(f"  → App:  http://localhost:{fp}")
-    print(f"  → Docs: http://localhost:{dp}")
     print(f"  → API:  http://localhost:{bp}/docs")
+    print(f"  → Docs: {DOCS_URL}")
     print()
 
 


### PR DESCRIPTION
## Summary

Moves the Docusaurus docs site from local startup to GitHub Pages. Faster install, fewer things to break.

### Changes
- **GitHub Actions workflow** deploys docs to GitHub Pages on push to main
- **Header "Docs" link** now points to `https://shaunyogeshwaran.github.io/Shaun_FYP/`
- **Removed docs from `make install`** — no more `cd docs && npm install` (saves ~2 min)
- **Removed docs from `make start`** — only backend + frontend start locally
- **`docusaurus.config.js`** supports `BASE_URL` env var for GitHub Pages `/Shaun_FYP/` prefix

### Before
- `make install` installs 1285 docs packages (2 min)
- `make start` starts 3 servers, docs often fails on port conflicts
- Docs link points to localhost:4000

### After
- `make install` only installs frontend (70 packages)
- `make start` starts 2 servers — backend + frontend
- Docs always available at GitHub Pages URL

## Test plan
- [ ] `make install && make start` — only backend + frontend start
- [ ] "Docs" link in header opens GitHub Pages site
- [ ] Push to main triggers docs deployment workflow
- [ ] Enable GitHub Pages (Settings → Pages → Source: GitHub Actions) after merge