### PR TITLE
Fix Docusaurus GitHub Pages build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,9 +27,12 @@ jobs:
 
       - name: Install and build docs
         working-directory: docs
+        env:
+          DOCS_URL: https://shaunyogeshwaran.github.io
+          BASE_URL: /Shaun_FYP/
         run: |
           npm install --no-fund --no-audit
-          DOCS_URL=https://shaunyogeshwaran.github.io BASE_URL=/Shaun_FYP/ npm run build
+          npx docusaurus build --no-minify
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions docs deployment that was failing with:
```
ValidationError: Invalid options object. Progress Plugin has been initialized 
using an options object that does not match the API schema.
```

Known Docusaurus 3.9.2 + webpack issue. Fix: use `--no-minify` flag.

## Test plan
- [ ] GitHub Actions workflow passes after merge
- [ ] Docs site live at https://shaunyogeshwaran.github.io/Shaun_FYP/