### PR TITLE
Pin Docusaurus 3.7.0 — fix GitHub Pages build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/core": "3.7.0",
+    "@docusaurus/preset-classic": "3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -23,8 +23,8 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/types": "3.9.2"
+    "@docusaurus/module-type-aliases": "3.7.0",
+    "@docusaurus/types": "3.7.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Docusaurus 3.9.2 has a webpack Progress Plugin validation error that breaks builds (even with --no-minify). Pin all Docusaurus packages to 3.7.0 which is the last stable version without this bug.

## Test plan
- [ ] GitHub Actions workflow passes
- [ ] Docs site deploys to https://shaunyogeshwaran.github.io/Shaun_FYP/