### PR TITLE
Pin webpack 5.105.4 — fix docs build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,17 +14,18 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.7.0",
-    "@docusaurus/preset-classic": "3.7.0",
+    "@docusaurus/core": "3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "webpack": "5.105.4"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.7.0",
-    "@docusaurus/types": "3.7.0"
+    "@docusaurus/module-type-aliases": "3.9.2",
+    "@docusaurus/types": "3.9.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

webpack 5.106.0's `ProgressPlugin` is incompatible with `webpackbar` 6.0.1 used by Docusaurus, causing the GitHub Pages build to fail. Same fix as h2oai/haic-documentation#391.

- Pin `webpack` to `5.105.4` in docs/package.json
- Restore Docusaurus back to 3.9.2 (the downgrade to 3.7.0 wasn't needed)

## Test plan
- [ ] GitHub Actions docs workflow passes
- [ ] Docs deploy to https://shaunyogeshwaran.github.io/Shaun_FYP/